### PR TITLE
Add WP-CLI ability (root-for-agents/wp-cli)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This plugin registers additional WordPress **Abilities** and surfaces them over 
 | Ability | Purpose |
 | --- | --- |
 | `root-for-agents/shell-exec` | Run arbitrary shell commands (`proc_open`), capturing stdout/stderr/exit code, with cwd + timeout. |
+| `root-for-agents/wp-cli` | Run a WP-CLI command against this install (everything after `wp`); auto-adds `--allow-root` when running as root. |
 | `root-for-agents/php-eval` | Evaluate arbitrary PHP in the loaded WordPress runtime; returns output, return value, and errors. |
 | `root-for-agents/file-read` | Read any file (binary-safe via base64). |
 | `root-for-agents/file-write` | Write any file, creating dirs; binary-safe; append mode. |
@@ -112,6 +113,12 @@ define( 'ROOT_FOR_AGENTS_AUDIT_LOG', '/path/to/audit.log' );
 
 ```json
 { "path": "wp-content/debug.log" }
+```
+
+`wp-cli` input:
+
+```json
+{ "command": "plugin list --status=active --format=json" }
 ```
 
 ## Philosophy

--- a/readme.txt
+++ b/readme.txt
@@ -17,6 +17,7 @@ Root for Agents fills the execution gap in the WordPress MCP ecosystem. The exis
 This plugin registers additional WordPress **Abilities** and exposes them over MCP. It bundles wordpress/mcp-adapter (loaded via the Jetpack Autoloader), so it works standalone — the separate MCP Adapter plugin is not required. It adds:
 
 * **Shell execution** (`root-for-agents/shell-exec`) — run arbitrary commands via proc_open(), capturing stdout/stderr/exit code with a working directory and timeout.
+* **WP-CLI execution** (`root-for-agents/wp-cli`) — run a WP-CLI command (everything after `wp`) against this install; runs from the WordPress root and auto-adds --allow-root when running as root.
 * **PHP runtime execution** (`root-for-agents/php-eval`) — evaluate arbitrary PHP inside the loaded WordPress runtime; returns printed output, the returned value, and any error.
 * **Filesystem access** (`root-for-agents/file-read`, `file-write`, `file-delete`, `file-list`) — read/write/delete arbitrary files (binary-safe via base64) and list directories recursively.
 * **Environment inspection** (`root-for-agents/env-inspect`) — versions, paths, active plugins/theme, debug flags, writable-ness, and available CLI tooling.
@@ -81,6 +82,6 @@ Intentionally high-trust. It does NOT implement sandboxing, granular ACLs, appro
 == Changelog ==
 
 = 0.1.0 =
-* Initial release: shell-exec, php-eval, file read/write/delete/list, env-inspect, process-exec abilities; environment gates; audit logging.
+* Initial release: shell-exec, wp-cli, php-eval, file read/write/delete/list, env-inspect, process-exec abilities; environment gates; audit logging.
 * Bundles wordpress/mcp-adapter via the Jetpack Autoloader so the plugin works standalone.
 * Adds a "Root for Agents > Connect" admin page that generates an application password and ready-to-paste connection instructions (agent prompt, Claude Code CLI command, and mcpServers JSON) for the @automattic/mcp-wordpress-remote proxy.

--- a/src/Abilities/WpCliAbility.php
+++ b/src/Abilities/WpCliAbility.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * Ability: root-for-agents/wp-cli
+ *
+ * @package RootForAgents
+ */
+
+declare( strict_types=1 );
+
+namespace RootForAgents\Abilities;
+
+use RootForAgents\Services\AuditLogger;
+use RootForAgents\Services\WpCliRunner;
+use RootForAgents\Support\Config;
+
+defined( 'ABSPATH' ) || exit;
+
+final class WpCliAbility {
+
+	public const NAME = 'root-for-agents/wp-cli';
+
+	public static function is_allowed(): bool {
+		return true;
+	}
+
+	/**
+	 * @return array<string,mixed>
+	 */
+	public static function definition(): array {
+		return array(
+			'label'               => 'Run WP-CLI Command',
+			'description'         => 'Run a WP-CLI command against this WordPress install and capture stdout, stderr, and the exit code. Provide everything after `wp` (e.g. "plugin list --status=active --format=json"). Runs from the WordPress root, and adds --allow-root automatically when running as root.',
+			'category'            => 'root-for-agents',
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'properties'           => array(
+					'command'    => array(
+						'type'        => 'string',
+						'description' => 'The WP-CLI command to run, i.e. everything after `wp`. Example: "option get siteurl". A leading "wp " is tolerated and stripped.',
+					),
+					'cwd'        => array(
+						'type'        => 'string',
+						'description' => 'Working directory. Defaults to the WordPress root (ABSPATH). Relative paths resolve against ABSPATH.',
+					),
+					'timeout_ms' => array(
+						'type'        => 'integer',
+						'description' => 'Wall-clock timeout in milliseconds. Defaults to the configured plugin timeout.',
+					),
+				),
+				'required'             => array( 'command' ),
+				'additionalProperties' => false,
+			),
+			'output_schema'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'stdout'          => array( 'type' => 'string' ),
+					'stdout_encoding' => array( 'type' => 'string', 'enum' => array( 'utf8', 'base64' ) ),
+					'stderr'          => array( 'type' => 'string' ),
+					'stderr_encoding' => array( 'type' => 'string', 'enum' => array( 'utf8', 'base64' ) ),
+					'exit_code'       => array( 'type' => 'integer' ),
+					'duration_ms'     => array( 'type' => 'integer' ),
+					'timed_out'       => array( 'type' => 'boolean' ),
+					'truncated'       => array( 'type' => 'boolean' ),
+				),
+			),
+			'execute_callback'    => AuditLogger::wrap(
+				self::NAME,
+				array( self::class, 'execute' ),
+				array( self::class, 'summarize' )
+			),
+			'permission_callback' => static function (): bool {
+				return Config::has_admin_access();
+			},
+			'meta'                => array(
+				'mcp'          => array( 'public' => true ),
+				'annotations'  => array(
+					'readonly'        => false,
+					'destructiveHint' => true,
+					'openWorldHint'   => true,
+				),
+				'show_in_rest' => true,
+			),
+		);
+	}
+
+	/**
+	 * @param array<string,mixed> $input
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	public static function execute( array $input ) {
+		$command    = isset( $input['command'] ) ? (string) $input['command'] : '';
+		$cwd        = isset( $input['cwd'] ) ? (string) $input['cwd'] : null;
+		$timeout_ms = isset( $input['timeout_ms'] ) ? (int) $input['timeout_ms'] : null;
+
+		return ( new WpCliRunner() )->run( $command, $cwd, $timeout_ms );
+	}
+
+	/**
+	 * @param array<string,mixed> $input
+	 * @return array<string,mixed>
+	 */
+	public static function summarize( array $input ): array {
+		return array(
+			'command' => isset( $input['command'] ) ? mb_substr( (string) $input['command'], 0, 500 ) : '',
+			'cwd'     => isset( $input['cwd'] ) ? (string) $input['cwd'] : null,
+		);
+	}
+}

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -17,6 +17,7 @@ use RootForAgents\Abilities\FileWriteAbility;
 use RootForAgents\Abilities\PhpEvalAbility;
 use RootForAgents\Abilities\ProcessExecAbility;
 use RootForAgents\Abilities\ShellAbility;
+use RootForAgents\Abilities\WpCliAbility;
 use RootForAgents\Admin\ConnectPage;
 
 defined( 'ABSPATH' ) || exit;
@@ -38,6 +39,7 @@ final class Plugin {
 		EnvInspectAbility::class,
 		ShellAbility::class,
 		ProcessExecAbility::class,
+		WpCliAbility::class,
 		PhpEvalAbility::class,
 		FileReadAbility::class,
 		FileWriteAbility::class,

--- a/src/Services/WpCliRunner.php
+++ b/src/Services/WpCliRunner.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * WP-CLI command execution.
+ *
+ * @package RootForAgents
+ */
+
+declare( strict_types=1 );
+
+namespace RootForAgents\Services;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Runs a WP-CLI command and captures its result.
+ *
+ * This is a thin convenience layer over ShellExecutor: it resolves the `wp`
+ * binary, runs the command from the WordPress root so WP-CLI finds the install,
+ * and transparently adds --allow-root when the PHP process is running as root
+ * (WP-CLI refuses to run as root otherwise). The command string is passed
+ * through verbatim — like shell-exec, the agent is trusted to have
+ * shell-equivalent access, so there is intentionally no argument escaping or
+ * command filtering.
+ */
+final class WpCliRunner {
+
+	/**
+	 * @param string  $command    The WP-CLI command, i.e. everything after `wp`
+	 *                            (e.g. "plugin list --status=active --format=json").
+	 * @param ?string $cwd        Working directory. Defaults to ABSPATH so WP-CLI
+	 *                            resolves the current install. Relative paths
+	 *                            resolve against ABSPATH.
+	 * @param ?int    $timeout_ms Override the default timeout.
+	 *
+	 * @return array{stdout:string,stderr:string,exit_code:int,duration_ms:int,timed_out:bool,truncated:bool,stdout_encoding:string,stderr_encoding:string}|\WP_Error
+	 */
+	public function run( string $command, ?string $cwd = null, ?int $timeout_ms = null ) {
+		$command = trim( $command );
+		if ( '' === $command ) {
+			return new \WP_Error( 'root_for_agents_empty_wp_cli', 'No WP-CLI command provided.' );
+		}
+
+		$binary = $this->resolve_binary();
+		if ( null === $binary ) {
+			return new \WP_Error(
+				'root_for_agents_wp_cli_unavailable',
+				'WP-CLI (the `wp` binary) was not found on this server. Install WP-CLI or use the shell-exec ability with an absolute path.'
+			);
+		}
+
+		// Tolerate a leading "wp " if the agent included it; we add the binary.
+		if ( 0 === stripos( $command, 'wp ' ) ) {
+			$command = ltrim( substr( $command, 3 ) );
+		}
+
+		$full = $binary . ' ' . $command;
+
+		// WP-CLI aborts when run as root unless --allow-root is set. Add it only
+		// when actually root and the caller hasn't already specified it.
+		if ( $this->is_root() && false === strpos( $command, '--allow-root' ) ) {
+			$full .= ' --allow-root';
+		}
+
+		// Default to ABSPATH so `wp` finds the WordPress install.
+		$cwd = ( null !== $cwd && '' !== trim( $cwd ) ) ? $cwd : ABSPATH;
+
+		return ( new ShellExecutor() )->run( $full, $cwd, $timeout_ms );
+	}
+
+	/**
+	 * Locate the `wp` executable: prefer PATH, then common install locations.
+	 */
+	private function resolve_binary(): ?string {
+		if ( function_exists( 'shell_exec' ) ) {
+			$out = @shell_exec( 'command -v wp 2>/dev/null' ); // phpcs:ignore WordPress.PHP.NoSilencedErrors, WordPress.PHP.DiscouragedPHPFunctions
+			if ( is_string( $out ) && '' !== trim( $out ) ) {
+				return trim( (string) strtok( $out, "\n" ) );
+			}
+		}
+
+		foreach ( array( '/usr/local/bin/wp', '/usr/bin/wp', '/bin/wp' ) as $candidate ) {
+			if ( is_executable( $candidate ) ) {
+				return $candidate;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Whether the PHP process is running with effective UID 0.
+	 */
+	private function is_root(): bool {
+		return function_exists( 'posix_geteuid' ) && 0 === posix_geteuid();
+	}
+}


### PR DESCRIPTION
## Summary

Adds a dedicated **WP-CLI ability** so agents can run `wp` commands directly instead of hand-building `wp … --allow-root` shell-exec invocations.

- **`WpCliRunner`** (`src/Services/WpCliRunner.php`) — resolves the `wp` binary (PATH via `command -v`, then `/usr/local/bin/wp`, `/usr/bin/wp`, `/bin/wp`), runs from `ABSPATH` so WP-CLI finds the install, and transparently appends `--allow-root` when the PHP process is root and the caller didn't already pass it. A leading `"wp "` in the command is tolerated and stripped. Thin layer over the existing `ShellExecutor` (same timeout + output-cap behavior).
- **`WpCliAbility`** (`src/Abilities/WpCliAbility.php`) — exposes it as **`root-for-agents/wp-cli`**. Input is a single `command` string (everything after `wp`), plus optional `cwd` / `timeout_ms`. Returns the same `stdout/stderr/exit_code/...` shape as shell-exec. Audit-logged and gated to admins/super admins via the shared `Config::has_admin_access()` permission callback.
- Registered in `Plugin`; documented in `README.md` and `readme.txt`.

Per design: the command is passed through **verbatim** (no escaping/filtering — consistent with shell-exec's trust model) and **no `--format` is injected** (the agent decides output format).

## Testing

Verified directly against the live install via `WpCliRunner`:

- `option get siteurl` → `http://localhost:8090`, exit 0
- leading `"wp "` stripped (`wp core version` works)
- `plugin list --status=active --format=json` → JSON passed through untouched
- empty command → `WP_Error` (`root_for_agents_empty_wp_cli`)
- `nonexistent-subcommand-xyz` → **exit_code 1** with stderr captured

The full MCP path (`execute-ability` over HTTP with app-password Basic auth) was verified on the stacked follow-up branch using the identical code — `success: true`, `exit_code: 0`, `isError: false`. (The adapter's `execute-ability` tool takes `ability_name` + `parameters`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)