### PR TITLE
Settings screen: explicit enable, production gate, domain lock, admin login link

### DIFF
--- a/plugin/README.md
+++ b/plugin/README.md
@@ -19,6 +19,7 @@ This plugin registers additional WordPress **Abilities** and surfaces them over 
 | `agent-connector-for-wp/file-list` | List a directory, optionally recursively. |
 | `agent-connector-for-wp/env-inspect` | WP/PHP versions, paths, active plugins/theme, debug state, writable-ness, available CLI tools. |
 | `agent-connector-for-wp/process-exec` | Longer-running command execution (proxies shell-exec in v1). |
+| `agent-connector-for-wp/create-admin-login-link` | Mint a one-time, short-lived URL that logs a browser into wp-admin as the requesting super admin (for browser-driving agents that hold only an application password). |
 
 The goal: give trusted agents in development environments effectively **SSH-equivalent** operational access through the existing WordPress MCP stack.
 
@@ -71,21 +72,22 @@ The application password is shown only once, embedded in those artifacts — cop
 it immediately. Treat it like an SSH key; revoke it from **Users → Profile →
 Application Passwords** when you're done.
 
-## Enable (mandatory gates)
+## Enable
 
-The plugin is inert until you explicitly opt in. Add to `wp-config.php`:
+The plugin is completely inert until a human explicitly switches it on — there is
+no environment heuristic and no enabling constant. Go to **Agent Connector for WP
+→ Settings** in wp-admin and tick *Enable Agent Connector*. This screen is always
+available, even while the plugin is off, and enabling here also locks the plugin
+to the current domain.
 
-```php
-define( 'AGENT_CONNECTOR_FOR_WP_ENABLED', true );
-```
+### Domain lock
 
-It also refuses to run when `wp_get_environment_type()` is `production`, unless you additionally (and inadvisably) set:
-
-```php
-define( 'AGENT_CONNECTOR_FOR_WP_ALLOW_PRODUCTION', true );
-```
-
-All abilities register when `AGENT_CONNECTOR_FOR_WP_ENABLED` is true.
+When enabled (or when you click **Reconnect to this domain**), the plugin records
+the site's declared home host. If the site is later cloned or moved to a
+different domain, every ability is blocked and returns an error telling the agent
+that an administrator must reconnect from **Agent Connector for WP → Settings** —
+so a copied database (and the application passwords in it) can't silently grant
+access on another site.
 
 ### Optional tunables
 

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -1,6 +1,6 @@
 # Agent Connector for WP
 
-> ⚠️ **Dangerous by design.** This plugin grants root-equivalent operational capability — arbitrary shell, PHP eval, and filesystem access — to authenticated administrators/super admins and the agents acting on their behalf. It is **not sandboxed** and **not for production**. Install it only in trusted local/dev/staging environments where you would be comfortable handing out a root shell.
+> ⚠️ **Dangerous by design.** This plugin grants root-equivalent operational capability — arbitrary shell, PHP eval, and filesystem access — to authenticated administrators/super admins and the agents acting on their behalf. It is **not sandboxed**. On a `production` environment type it stays inactive until you explicitly tick a production override; everywhere else the Enable toggle is enough. Only turn it on where you would be comfortable handing out a root shell.
 
 Agent Connector for WP fills the execution gap in the WordPress MCP ecosystem. The existing stack — the [WordPress AI plugin](https://wordpress.org/plugins/ai/), the MCP Abilities API, and [`wordpress/mcp-adapter`](https://github.com/WordPress/mcp-adapter) — provides structured tools and abilities, but agents still lack unrestricted operational access.
 
@@ -75,10 +75,19 @@ Application Passwords** when you're done.
 ## Enable
 
 The plugin is completely inert until a human explicitly switches it on — there is
-no environment heuristic and no enabling constant. Go to **Agent Connector for WP
-→ Settings** in wp-admin and tick *Enable Agent Connector*. This screen is always
-available, even while the plugin is off, and enabling here also locks the plugin
-to the current domain.
+no enabling constant. Go to **Agent Connector for WP → Settings** in wp-admin and
+tick *Enable Agent Connector*. This screen is always available, even while the
+plugin is off, and enabling here also locks the plugin to the current domain.
+
+Enabling has two gates:
+
+1. **Enable Agent Connector** — the master toggle.
+2. **Production override** — only required when `wp_get_environment_type()` reports
+   `production` (also the default when the environment type was never configured).
+   On `local` / `development` / `staging` the master toggle alone activates the
+   plugin; on `production` you must additionally tick the override, which is where
+   the danger warning lives. This makes it hard to accidentally expose
+   root-equivalent access on a live site.
 
 ### Domain lock
 

--- a/plugin/agent-connector-for-wp.php
+++ b/plugin/agent-connector-for-wp.php
@@ -85,15 +85,22 @@ unset( $agent_connector_for_wp_has_vendor );
 /**
  * Boot the plugin once WordPress is loaded.
  *
- * The plugin is inert unless the operator has explicitly opted in via the
- * mandatory environment gates (see Support\Config). This keeps a stray
- * activation from ever exposing dangerous abilities by accident.
+ * The plugin is inert unless the operator has explicitly switched it on via the
+ * Settings toggle (see Support\Config). This keeps a stray activation from ever
+ * exposing dangerous abilities by accident.
  */
 add_action(
 	'plugins_loaded',
 	static function (): void {
+		// The Settings screen is always available — even while inert — because
+		// it's the only place to switch the plugin on. It registers nothing
+		// dangerous; the boot gate below still guards every ability.
+		if ( is_admin() ) {
+			( new Admin\SettingsPage() )->register();
+		}
+
 		if ( ! Support\Config::can_boot() ) {
-			// Surface *why* in the admin so the gate isn't a silent mystery.
+			// Surface *why* it's off so the disabled state isn't a silent mystery.
 			add_action( 'admin_notices', array( Support\Config::class, 'render_gate_notice' ) );
 			return;
 		}

--- a/plugin/readme.txt
+++ b/plugin/readme.txt
@@ -33,7 +33,7 @@ This plugin is **dangerous by design**. It is:
 * developer-focused
 * intentionally unrestricted
 * **NOT** sandboxed
-* **NOT** intended for production
+* blocked on production environments unless you explicitly tick the production override
 * **NOT** enterprise security software
 
 It assumes the environment is trusted and that authenticated administrators intentionally trust the agents acting on their behalf. Do not install it anywhere you would not hand out a root shell.
@@ -50,7 +50,12 @@ wordpress/mcp-adapter is bundled with this plugin; you do not need to install it
 
 == Enabling the Plugin ==
 
-The plugin is completely inert until a human explicitly switches it on — there is no environment heuristic and no enabling constant. Go to **Agent Connector for WP > Settings** in wp-admin and tick *Enable Agent Connector*. The Settings screen is always available, even while the plugin is off.
+The plugin is completely inert until a human explicitly switches it on — there is no enabling constant. Go to **Agent Connector for WP > Settings** in wp-admin and tick *Enable Agent Connector*. The Settings screen is always available, even while the plugin is off.
+
+Enabling has two gates:
+
+1. **Enable Agent Connector** — the master toggle.
+2. **Production override** — required only when `wp_get_environment_type()` reports `production` (which is also the default when the environment type is never configured). On a `local`, `development`, or `staging` site the master toggle alone activates the plugin; on `production` you must additionally tick the override, which is where the danger warning lives. This makes it hard to accidentally expose root-equivalent access on a live site.
 
 Enabling also locks the plugin to the current domain (see the Security Model below).
 
@@ -73,7 +78,8 @@ Go to **Agent Connector for WP > Connect** in wp-admin and click **Generate conn
 Intentionally high-trust. It does NOT implement sandboxing, granular ACLs, approval workflows, restricted shells, or command whitelisting. It DOES enforce:
 
 * administrator/super-admin checks (`manage_options` + `is_super_admin()`) on every ability
-* explicit opt-in: off until enabled via the Settings screen or the wp-config constant
+* explicit opt-in: off until enabled via the Settings screen
+* the production gate: on a production environment type, abilities stay inactive until the operator also ticks the production override
 * the domain lock (abilities refuse to run on a domain the plugin was not enabled on)
 * timeout enforcement and output caps
 * append-only audit logging of every invocation (user, ability, input summary, status, duration)
@@ -82,7 +88,7 @@ Intentionally high-trust. It does NOT implement sandboxing, granular ACLs, appro
 
 = 0.1.0 =
 * Initial release: shell-exec, wp-cli, php-eval, file read/write/delete/list, env-inspect, process-exec, create-admin-login-link abilities; audit logging.
-* Explicit opt-in enable model: off until enabled via the Settings screen (no environment heuristic, no enabling constant).
+* Explicit opt-in enable model: off until enabled via the Settings screen (no enabling constant). On a production environment type, a second explicit override is required before abilities activate.
 * Domain lock: abilities are blocked, with an agent-actionable error, if the site is moved to a domain the plugin was not enabled on; reconnect from the Settings screen.
 * One-time admin login links so a browser-driving agent holding only an application password can reach wp-admin.
 * Bundles wordpress/mcp-adapter via the Jetpack Autoloader so the plugin works standalone.

--- a/plugin/readme.txt
+++ b/plugin/readme.txt
@@ -22,6 +22,7 @@ This plugin registers additional WordPress **Abilities** and exposes them over M
 * **Filesystem access** (`agent-connector-for-wp/file-read`, `file-write`, `file-delete`, `file-list`) — read/write/delete arbitrary files (binary-safe via base64) and list directories recursively.
 * **Environment inspection** (`agent-connector-for-wp/env-inspect`) — versions, paths, active plugins/theme, debug flags, writable-ness, and available CLI tooling.
 * **Process execution** (`agent-connector-for-wp/process-exec`) — longer-running command execution (proxies shell-exec in v1).
+* **Admin login link** (`agent-connector-for-wp/create-admin-login-link`) — mint a one-time, short-lived URL that logs a browser into wp-admin as the requesting super admin, so a browser-driving agent (e.g. Playwright) that only holds an application password can still use the admin UI.
 
 The goal: give trusted agents in local/development environments the same operational capabilities as a human administrator — effectively SSH-equivalent access — through the existing WordPress MCP stack.
 
@@ -47,17 +48,15 @@ It assumes the environment is trusted and that authenticated administrators inte
 
 wordpress/mcp-adapter is bundled with this plugin; you do not need to install it separately.
 
-== Mandatory Environment Gates ==
+== Enabling the Plugin ==
 
-The plugin refuses to initialize unless explicitly enabled. Add to `wp-config.php`:
+The plugin is completely inert until a human explicitly switches it on — there is no environment heuristic and no enabling constant. Go to **Agent Connector for WP > Settings** in wp-admin and tick *Enable Agent Connector*. The Settings screen is always available, even while the plugin is off.
 
-`define( 'AGENT_CONNECTOR_FOR_WP_ENABLED', true );`
+Enabling also locks the plugin to the current domain (see the Security Model below).
 
-Additionally, the plugin will not run when `wp_get_environment_type()` is `production` unless you also define:
+== Domain Lock ==
 
-`define( 'AGENT_CONNECTOR_FOR_WP_ALLOW_PRODUCTION', true );  // not recommended`
-
-All abilities are registered when `AGENT_CONNECTOR_FOR_WP_ENABLED` is true.
+When you enable the plugin (or click **Reconnect to this domain**), it records the site's declared home host. If the site is later cloned or moved to a different domain, every ability is blocked and returns an error telling the calling agent that an administrator must visit **Agent Connector for WP > Settings** and click **Reconnect to this domain**. This stops a copied database — and the application passwords inside it — from silently granting access on a different site.
 
 == Connecting an Agent ==
 
@@ -74,14 +73,17 @@ Go to **Agent Connector for WP > Connect** in wp-admin and click **Generate conn
 Intentionally high-trust. It does NOT implement sandboxing, granular ACLs, approval workflows, restricted shells, or command whitelisting. It DOES enforce:
 
 * administrator/super-admin checks (`manage_options` + `is_super_admin()`) on every ability
-* the mandatory environment gates above
-* the production guard
+* explicit opt-in: off until enabled via the Settings screen or the wp-config constant
+* the domain lock (abilities refuse to run on a domain the plugin was not enabled on)
 * timeout enforcement and output caps
 * append-only audit logging of every invocation (user, ability, input summary, status, duration)
 
 == Changelog ==
 
 = 0.1.0 =
-* Initial release: shell-exec, wp-cli, php-eval, file read/write/delete/list, env-inspect, process-exec abilities; environment gates; audit logging.
+* Initial release: shell-exec, wp-cli, php-eval, file read/write/delete/list, env-inspect, process-exec, create-admin-login-link abilities; audit logging.
+* Explicit opt-in enable model: off until enabled via the Settings screen (no environment heuristic, no enabling constant).
+* Domain lock: abilities are blocked, with an agent-actionable error, if the site is moved to a domain the plugin was not enabled on; reconnect from the Settings screen.
+* One-time admin login links so a browser-driving agent holding only an application password can reach wp-admin.
 * Bundles wordpress/mcp-adapter via the Jetpack Autoloader so the plugin works standalone.
-* Adds a "Agent Connector for WP > Connect" admin page that generates an application password and ready-to-paste connection instructions (agent prompt, Claude Code CLI command, and mcpServers JSON) for the @automattic/mcp-wordpress-remote proxy.
+* Adds an "Agent Connector for WP > Connect" admin page that generates an application password and ready-to-paste connection instructions (agent prompt, Claude Code CLI command, and mcpServers JSON) for the @automattic/mcp-wordpress-remote proxy.

--- a/plugin/src/Abilities/AdminLoginAbility.php
+++ b/plugin/src/Abilities/AdminLoginAbility.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * Ability: agent-connector-for-wp/create-admin-login-link
+ *
+ * @package AgentConnectorForWp
+ */
+
+declare( strict_types=1 );
+
+namespace AgentConnectorForWp\Abilities;
+
+use AgentConnectorForWp\Services\AdminLoginLink;
+use AgentConnectorForWp\Services\AuditLogger;
+use AgentConnectorForWp\Support\Config;
+use WP_Error;
+
+defined( 'ABSPATH' ) || exit;
+
+final class AdminLoginAbility {
+
+	public const NAME = 'agent-connector-for-wp/create-admin-login-link';
+
+	public static function is_allowed(): bool {
+		return true;
+	}
+
+	/**
+	 * @return array<string,mixed>
+	 */
+	public static function definition(): array {
+		return array(
+			'label'               => 'Create Admin Login Link',
+			'description'         => 'Mint a one-time, short-lived URL that logs a browser into wp-admin as the current super-admin user. Intended for browser-driving agents (e.g. Playwright) that authenticate to MCP with an application password and have no admin session of their own: open the returned login_url in the browser to get a logged-in wp-admin. The link works once and expires (default 5 minutes). The URL is built from the host used to reach this site, so it is reachable from wherever the request originated.',
+			'category'            => 'agent-connector-for-wp',
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'properties'           => array(
+					'redirect_to' => array(
+						'type'        => 'string',
+						'description' => 'Admin-relative page to land on after login, e.g. "plugins.php" or "options-general.php". Defaults to the dashboard ("index.php"). Absolute URLs are rejected.',
+					),
+					'ttl_seconds' => array(
+						'type'        => 'integer',
+						'description' => 'How long the link stays valid, in seconds. Clamped to [30, 900]. Defaults to 300 (5 minutes).',
+					),
+				),
+				'additionalProperties' => false,
+			),
+			'output_schema'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'login_url'          => array(
+						'type'        => 'string',
+						'description' => 'Open this once in a browser to land in wp-admin, logged in.',
+					),
+					'expires_at'         => array(
+						'type'        => 'string',
+						'description' => 'ISO-8601 (UTC) expiry timestamp.',
+					),
+					'expires_in_seconds' => array( 'type' => 'integer' ),
+				),
+			),
+			'execute_callback'    => AuditLogger::wrap(
+				self::NAME,
+				array( self::class, 'execute' ),
+				array( self::class, 'summarize' )
+			),
+			'permission_callback' => static function (): bool {
+				return Config::has_admin_access();
+			},
+			'meta'                => array(
+				'mcp'          => array( 'public' => true ),
+				'annotations'  => array(
+					'readonly'        => false,
+					'destructiveHint' => false,
+					'openWorldHint'   => false,
+				),
+				'show_in_rest' => true,
+			),
+		);
+	}
+
+	/**
+	 * @param array<string,mixed> $input
+	 * @return array<string,mixed>|WP_Error
+	 */
+	public static function execute( array $input ) {
+		$user = wp_get_current_user();
+		if ( ! ( $user instanceof \WP_User ) || ! $user->exists() ) {
+			return new WP_Error( 'agent_connector_login_no_user', 'Could not determine the current user.', array( 'status' => 400 ) );
+		}
+
+		$redirect_to = isset( $input['redirect_to'] ) ? (string) $input['redirect_to'] : '';
+		$ttl_seconds = isset( $input['ttl_seconds'] ) ? (int) $input['ttl_seconds'] : AdminLoginLink::DEFAULT_TTL;
+
+		return AdminLoginLink::create( $user->ID, $redirect_to, $ttl_seconds );
+	}
+
+	/**
+	 * @param array<string,mixed> $input
+	 * @return array<string,mixed>
+	 */
+	public static function summarize( array $input ): array {
+		return array(
+			'redirect_to' => isset( $input['redirect_to'] ) ? (string) $input['redirect_to'] : '',
+			'ttl_seconds' => isset( $input['ttl_seconds'] ) ? (int) $input['ttl_seconds'] : AdminLoginLink::DEFAULT_TTL,
+		);
+	}
+}

--- a/plugin/src/Admin/ConnectPage.php
+++ b/plugin/src/Admin/ConnectPage.php
@@ -11,6 +11,7 @@ namespace AgentConnectorForWp\Admin;
 
 use AgentConnectorForWp\Support\Connection;
 use AgentConnectorForWp\Support\Config;
+use AgentConnectorForWp\Admin\SettingsPage;
 use WP_Application_Passwords;
 use WP_Error;
 
@@ -27,7 +28,7 @@ defined( 'ABSPATH' ) || exit;
  */
 final class ConnectPage {
 
-	private const MENU_SLUG = 'agent-connector-for-wp';
+	private const MENU_SLUG = 'agent-connector-for-wp-connect';
 	private const AJAX_ACTION = 'rfa_generate_connection';
 
 	/**
@@ -42,22 +43,13 @@ final class ConnectPage {
 	}
 
 	/**
-	 * Add the top-level menu and Connect page.
+	 * Add the Connect page as a submenu under the (always-present) Agent
+	 * Connector top-level menu owned by SettingsPage. Only registered when the
+	 * plugin is booted, so it appears once abilities are actually enabled.
 	 */
 	public function register_menu(): void {
-		$this->hook_suffix = (string) add_menu_page(
-			__( 'Agent Connector for WP', 'agent-connector-for-wp' ),
-			__( 'Agent Connector for WP', 'agent-connector-for-wp' ),
-			Config::CAP,
-			self::MENU_SLUG,
-			array( $this, 'render_page' ),
-			'dashicons-superhero-alt',
-			81
-		);
-
-		// Give the submenu item a friendlier label than the menu title.
-		add_submenu_page(
-			self::MENU_SLUG,
+		$this->hook_suffix = (string) add_submenu_page(
+			SettingsPage::MENU_SLUG,
 			__( 'Connect an Agent', 'agent-connector-for-wp' ),
 			__( 'Connect', 'agent-connector-for-wp' ),
 			Config::CAP,

--- a/plugin/src/Admin/SettingsPage.php
+++ b/plugin/src/Admin/SettingsPage.php
@@ -72,34 +72,45 @@ final class SettingsPage {
 			return;
 		}
 
-		$enabled        = Config::is_enabled();
-		$locked_host    = Config::locked_host();
-		$declared_host  = Config::declared_host();
-		$lock_mismatch  = $enabled && '' !== $locked_host && $locked_host !== $declared_host;
-		$notice         = isset( $_GET['acfw_notice'] ) ? sanitize_key( wp_unslash( $_GET['acfw_notice'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$enabled       = Config::is_enabled();          // box 1.
+		$active        = Config::can_boot();             // truly running.
+		$non_prod      = Config::is_non_production_env();
+		$override      = Config::production_override_enabled(); // box 2.
+		$prod_blocked  = Config::is_blocked_by_production();
+		$env_type      = function_exists( 'wp_get_environment_type' ) ? wp_get_environment_type() : 'unknown';
+		$locked_host   = Config::locked_host();
+		$declared_host = Config::declared_host();
+		$lock_mismatch = $active && '' !== $locked_host && $locked_host !== $declared_host;
+		$notice        = isset( $_GET['acfw_notice'] ) ? sanitize_key( wp_unslash( $_GET['acfw_notice'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		?>
 		<div class="wrap">
 			<h1><?php esc_html_e( 'Agent Connector for WP — Settings', 'agent-connector-for-wp' ); ?></h1>
 
 			<?php $this->render_status_notice( $notice ); ?>
 
-			<div class="notice notice-error inline" style="max-width:48em;">
-				<p>
-					<strong><?php esc_html_e( 'Danger:', 'agent-connector-for-wp' ); ?></strong>
-					<?php esc_html_e( 'When enabled, this plugin grants root-equivalent control of this server — arbitrary shell commands, PHP evaluation, and filesystem access — to anyone holding a WordPress application password, and to the agents acting for them. There is no sandbox. Enable it only on trusted local, development, or staging environments. Never on production.', 'agent-connector-for-wp' ); ?>
-				</p>
-			</div>
-
 			<h2><?php esc_html_e( 'Status', 'agent-connector-for-wp' ); ?></h2>
 			<table class="form-table" role="presentation">
 				<tr>
 					<th scope="row"><?php esc_html_e( 'Abilities', 'agent-connector-for-wp' ); ?></th>
 					<td>
-						<?php if ( $enabled ) : ?>
-							<span style="color:#996800;font-weight:600;"><?php esc_html_e( 'ENABLED', 'agent-connector-for-wp' ); ?></span>
+						<?php if ( $active ) : ?>
+							<span style="color:#996800;font-weight:600;"><?php esc_html_e( 'ACTIVE', 'agent-connector-for-wp' ); ?></span>
+							<p class="description"><?php esc_html_e( 'Abilities are registered and exposed to agents over MCP.', 'agent-connector-for-wp' ); ?></p>
+						<?php elseif ( $prod_blocked ) : ?>
+							<span style="color:#b32d2e;font-weight:600;"><?php esc_html_e( 'Enabled, but inactive', 'agent-connector-for-wp' ); ?></span>
+							<p class="description"><?php esc_html_e( 'This is a production environment, so the Enable toggle alone does not activate it. Tick the production override below to activate.', 'agent-connector-for-wp' ); ?></p>
 						<?php else : ?>
 							<span style="color:#1a7f37;font-weight:600;"><?php esc_html_e( 'Disabled', 'agent-connector-for-wp' ); ?></span>
 							<p class="description"><?php esc_html_e( 'The plugin is inert. No abilities are registered and the MCP endpoint exposes nothing from this plugin.', 'agent-connector-for-wp' ); ?></p>
+						<?php endif; ?>
+					</td>
+				</tr>
+				<tr>
+					<th scope="row"><?php esc_html_e( 'Environment type', 'agent-connector-for-wp' ); ?></th>
+					<td>
+						<code><?php echo esc_html( $env_type ); ?></code>
+						<?php if ( ! $non_prod ) : ?>
+							<span class="description"><?php esc_html_e( '— treated as production; enabling requires the override below.', 'agent-connector-for-wp' ); ?></span>
 						<?php endif; ?>
 					</td>
 				</tr>
@@ -126,11 +137,33 @@ final class SettingsPage {
 							</p>
 						</td>
 					</tr>
+					<?php if ( ! $non_prod ) : ?>
+						<tr>
+							<th scope="row"><?php esc_html_e( 'Production override', 'agent-connector-for-wp' ); ?></th>
+							<td>
+								<div class="notice notice-error inline" style="margin:0 0 .9em;max-width:46em;">
+									<p>
+										<strong><?php esc_html_e( 'Danger:', 'agent-connector-for-wp' ); ?></strong>
+										<?php esc_html_e( 'This site reports a production environment type. Agent Connector grants root-equivalent control of this server — arbitrary shell commands, PHP evaluation, and filesystem access — to anyone holding a WordPress application password, and to the agents acting for them. There is no sandbox. On production this is almost never what you want; leave this unticked unless you fully accept that risk.', 'agent-connector-for-wp' ); ?>
+									</p>
+								</div>
+								<label>
+									<input
+										type="checkbox"
+										name="acfw_allow_production"
+										value="1"
+										<?php checked( $override ); ?>
+									/>
+									<?php esc_html_e( 'I understand the risk — run Agent Connector on this production environment anyway.', 'agent-connector-for-wp' ); ?>
+								</label>
+							</td>
+						</tr>
+					<?php endif; ?>
 				</table>
 				<?php submit_button( $enabled ? __( 'Save changes', 'agent-connector-for-wp' ) : __( 'Enable plugin', 'agent-connector-for-wp' ) ); ?>
 			</form>
 
-			<?php if ( $enabled ) : ?>
+			<?php if ( $active ) : ?>
 				<hr />
 				<h2><?php esc_html_e( 'Domain lock', 'agent-connector-for-wp' ); ?></h2>
 				<p style="max-width:48em;">
@@ -189,6 +222,7 @@ final class SettingsPage {
 			'enabled'    => array( 'success', __( 'Agent Connector is now enabled and locked to this domain.', 'agent-connector-for-wp' ) ),
 			'disabled'   => array( 'success', __( 'Agent Connector is now disabled. The plugin is inert.', 'agent-connector-for-wp' ) ),
 			'saved'      => array( 'success', __( 'Settings saved.', 'agent-connector-for-wp' ) ),
+			'prod_blocked' => array( 'warning', __( 'Saved, but Agent Connector is inactive: this is a production environment. Tick the production override to activate it.', 'agent-connector-for-wp' ) ),
 			'reconnected' => array( 'success', __( 'Reconnected — abilities are allowed on this domain again.', 'agent-connector-for-wp' ) ),
 		);
 
@@ -211,13 +245,19 @@ final class SettingsPage {
 
 		$was_enabled = Config::is_enabled();
 		$enable      = isset( $_POST['acfw_enabled'] ) && '1' === $_POST['acfw_enabled']; // phpcs:ignore WordPress.Security.NonceVerification.Missing
+		$allow_prod  = isset( $_POST['acfw_allow_production'] ) && '1' === $_POST['acfw_allow_production']; // phpcs:ignore WordPress.Security.NonceVerification.Missing
 
 		update_option( Config::ENABLED_OPTION, $enable, true );
+		update_option( Config::PRODUCTION_OVERRIDE_OPTION, $allow_prod, true );
 
 		if ( $enable ) {
 			// (Re)lock to the current domain whenever we transition to enabled.
 			if ( ! $was_enabled ) {
 				Config::lock_to_current_host();
+			}
+			// Enabled on production without the override → saved but not active.
+			if ( ! Config::can_boot() ) {
+				$this->redirect( 'prod_blocked' );
 			}
 			$this->redirect( $was_enabled ? 'saved' : 'enabled' );
 		}

--- a/plugin/src/Admin/SettingsPage.php
+++ b/plugin/src/Admin/SettingsPage.php
@@ -144,7 +144,7 @@ final class SettingsPage {
 								<div class="notice notice-error inline" style="margin:0 0 .9em;max-width:46em;">
 									<p>
 										<strong><?php esc_html_e( 'Danger:', 'agent-connector-for-wp' ); ?></strong>
-										<?php esc_html_e( 'This site reports a production environment type. Agent Connector grants root-equivalent control of this server — arbitrary shell commands, PHP evaluation, and filesystem access — to anyone holding a WordPress application password, and to the agents acting for them. There is no sandbox. On production this is almost never what you want; leave this unticked unless you fully accept that risk.', 'agent-connector-for-wp' ); ?>
+										<?php esc_html_e( 'This site reports a production environment type. Agent Connector grants admin-equivalent control of this site — arbitrary shell commands, PHP evaluation, and filesystem access — to anyone holding a WordPress application password, and to the agents acting for them. There is no sandbox. Leave this unticked unless you fully accept that risk.', 'agent-connector-for-wp' ); ?>
 									</p>
 								</div>
 								<label>

--- a/plugin/src/Admin/SettingsPage.php
+++ b/plugin/src/Admin/SettingsPage.php
@@ -1,0 +1,262 @@
+<?php
+/**
+ * Admin menu owner + "Settings" page (enable toggle and domain lock).
+ *
+ * @package AgentConnectorForWp
+ */
+
+declare( strict_types=1 );
+
+namespace AgentConnectorForWp\Admin;
+
+use AgentConnectorForWp\Support\Config;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * The Settings screen, and the owner of the top-level admin menu.
+ *
+ * This page is registered *unconditionally* (even when the plugin is switched
+ * off), because it is the only place an operator can switch it on. Everything
+ * dangerous stays gated behind Config::can_boot(); this screen just flips the
+ * switch and manages the domain lock.
+ *
+ * Form submissions go through admin-post.php (admin_post_* actions) so we can
+ * validate, mutate, and redirect with a status — no Settings API, matching the
+ * plugin's existing manual-nonce style.
+ */
+final class SettingsPage {
+
+	public const MENU_SLUG = 'agent-connector-for-wp';
+
+	private const SAVE_ACTION      = 'agent_connector_for_wp_save_settings';
+	private const RECONNECT_ACTION = 'agent_connector_for_wp_reconnect';
+
+	public function register(): void {
+		add_action( 'admin_menu', array( $this, 'register_menu' ) );
+		add_action( 'admin_post_' . self::SAVE_ACTION, array( $this, 'handle_save' ) );
+		add_action( 'admin_post_' . self::RECONNECT_ACTION, array( $this, 'handle_reconnect' ) );
+	}
+
+	/**
+	 * Register the top-level menu and the Settings page. ConnectPage adds its own
+	 * submenu under this slug when the plugin is booted.
+	 */
+	public function register_menu(): void {
+		add_menu_page(
+			__( 'Agent Connector for WP', 'agent-connector-for-wp' ),
+			__( 'Agent Connector for WP', 'agent-connector-for-wp' ),
+			Config::CAP,
+			self::MENU_SLUG,
+			array( $this, 'render_page' ),
+			'dashicons-superhero-alt',
+			81
+		);
+
+		// Rename the auto-created first submenu item to "Settings".
+		add_submenu_page(
+			self::MENU_SLUG,
+			__( 'Agent Connector Settings', 'agent-connector-for-wp' ),
+			__( 'Settings', 'agent-connector-for-wp' ),
+			Config::CAP,
+			self::MENU_SLUG,
+			array( $this, 'render_page' )
+		);
+	}
+
+	/**
+	 * Render the Settings screen.
+	 */
+	public function render_page(): void {
+		if ( ! current_user_can( Config::CAP ) ) {
+			return;
+		}
+
+		$enabled        = Config::is_enabled();
+		$locked_host    = Config::locked_host();
+		$declared_host  = Config::declared_host();
+		$lock_mismatch  = $enabled && '' !== $locked_host && $locked_host !== $declared_host;
+		$notice         = isset( $_GET['acfw_notice'] ) ? sanitize_key( wp_unslash( $_GET['acfw_notice'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		?>
+		<div class="wrap">
+			<h1><?php esc_html_e( 'Agent Connector for WP — Settings', 'agent-connector-for-wp' ); ?></h1>
+
+			<?php $this->render_status_notice( $notice ); ?>
+
+			<div class="notice notice-error inline" style="max-width:48em;">
+				<p>
+					<strong><?php esc_html_e( 'Danger:', 'agent-connector-for-wp' ); ?></strong>
+					<?php esc_html_e( 'When enabled, this plugin grants root-equivalent control of this server — arbitrary shell commands, PHP evaluation, and filesystem access — to anyone holding a WordPress application password, and to the agents acting for them. There is no sandbox. Enable it only on trusted local, development, or staging environments. Never on production.', 'agent-connector-for-wp' ); ?>
+				</p>
+			</div>
+
+			<h2><?php esc_html_e( 'Status', 'agent-connector-for-wp' ); ?></h2>
+			<table class="form-table" role="presentation">
+				<tr>
+					<th scope="row"><?php esc_html_e( 'Abilities', 'agent-connector-for-wp' ); ?></th>
+					<td>
+						<?php if ( $enabled ) : ?>
+							<span style="color:#996800;font-weight:600;"><?php esc_html_e( 'ENABLED', 'agent-connector-for-wp' ); ?></span>
+						<?php else : ?>
+							<span style="color:#1a7f37;font-weight:600;"><?php esc_html_e( 'Disabled', 'agent-connector-for-wp' ); ?></span>
+							<p class="description"><?php esc_html_e( 'The plugin is inert. No abilities are registered and the MCP endpoint exposes nothing from this plugin.', 'agent-connector-for-wp' ); ?></p>
+						<?php endif; ?>
+					</td>
+				</tr>
+			</table>
+
+			<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
+				<input type="hidden" name="action" value="<?php echo esc_attr( self::SAVE_ACTION ); ?>" />
+				<?php wp_nonce_field( self::SAVE_ACTION ); ?>
+				<table class="form-table" role="presentation">
+					<tr>
+						<th scope="row"><?php esc_html_e( 'Enable Agent Connector', 'agent-connector-for-wp' ); ?></th>
+						<td>
+							<label>
+								<input
+									type="checkbox"
+									name="acfw_enabled"
+									value="1"
+									<?php checked( $enabled ); ?>
+								/>
+								<?php esc_html_e( 'Allow agents to run shell, PHP, filesystem, WP-CLI, and admin-login abilities on this site.', 'agent-connector-for-wp' ); ?>
+							</label>
+							<p class="description">
+								<?php esc_html_e( 'Enabling also locks the plugin to this site\'s current domain (see below). Turn this off to make the plugin completely inert again.', 'agent-connector-for-wp' ); ?>
+							</p>
+						</td>
+					</tr>
+				</table>
+				<?php submit_button( $enabled ? __( 'Save changes', 'agent-connector-for-wp' ) : __( 'Enable plugin', 'agent-connector-for-wp' ) ); ?>
+			</form>
+
+			<?php if ( $enabled ) : ?>
+				<hr />
+				<h2><?php esc_html_e( 'Domain lock', 'agent-connector-for-wp' ); ?></h2>
+				<p style="max-width:48em;">
+					<?php esc_html_e( 'Agent Connector only runs on the domain it was enabled on. If this site is cloned or moved to another domain, abilities are blocked until an administrator reconnects here — so a copied database (and its application passwords) can\'t silently grant access on a different site.', 'agent-connector-for-wp' ); ?>
+				</p>
+
+				<?php if ( $lock_mismatch ) : ?>
+					<div class="notice notice-error inline" style="max-width:48em;">
+						<p>
+							<strong><?php esc_html_e( 'Domain mismatch — abilities are blocked.', 'agent-connector-for-wp' ); ?></strong>
+							<?php
+							printf(
+								/* translators: 1: locked host, 2: current host. */
+								esc_html__( 'Locked to %1$s, but this site now reports %2$s. Click "Reconnect to this domain" to allow abilities here.', 'agent-connector-for-wp' ),
+								'<code>' . esc_html( $locked_host ) . '</code>', // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+								'<code>' . esc_html( '' === $declared_host ? '(unknown)' : $declared_host ) . '</code>' // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+							);
+							?>
+						</p>
+					</div>
+				<?php endif; ?>
+
+				<table class="form-table" role="presentation">
+					<tr>
+						<th scope="row"><?php esc_html_e( 'Locked to', 'agent-connector-for-wp' ); ?></th>
+						<td><code><?php echo esc_html( '' === $locked_host ? __( '(not locked)', 'agent-connector-for-wp' ) : $locked_host ); ?></code></td>
+					</tr>
+					<tr>
+						<th scope="row"><?php esc_html_e( 'This site reports', 'agent-connector-for-wp' ); ?></th>
+						<td><code><?php echo esc_html( '' === $declared_host ? __( '(unknown)', 'agent-connector-for-wp' ) : $declared_host ); ?></code></td>
+					</tr>
+				</table>
+
+				<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
+					<input type="hidden" name="action" value="<?php echo esc_attr( self::RECONNECT_ACTION ); ?>" />
+					<?php wp_nonce_field( self::RECONNECT_ACTION ); ?>
+					<?php
+					submit_button(
+						__( 'Reconnect to this domain', 'agent-connector-for-wp' ),
+						$lock_mismatch ? 'primary' : 'secondary',
+						'submit',
+						false
+					);
+					?>
+				</form>
+			<?php endif; ?>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Render the post-redirect status notice.
+	 */
+	private function render_status_notice( string $notice ): void {
+		$messages = array(
+			'enabled'    => array( 'success', __( 'Agent Connector is now enabled and locked to this domain.', 'agent-connector-for-wp' ) ),
+			'disabled'   => array( 'success', __( 'Agent Connector is now disabled. The plugin is inert.', 'agent-connector-for-wp' ) ),
+			'saved'      => array( 'success', __( 'Settings saved.', 'agent-connector-for-wp' ) ),
+			'reconnected' => array( 'success', __( 'Reconnected — abilities are allowed on this domain again.', 'agent-connector-for-wp' ) ),
+		);
+
+		if ( ! isset( $messages[ $notice ] ) ) {
+			return;
+		}
+
+		printf(
+			'<div class="notice notice-%s is-dismissible"><p>%s</p></div>',
+			esc_attr( $messages[ $notice ][0] ),
+			esc_html( $messages[ $notice ][1] )
+		);
+	}
+
+	/**
+	 * admin-post: persist the enable toggle (and lock the domain on enable).
+	 */
+	public function handle_save(): void {
+		$this->verify( self::SAVE_ACTION );
+
+		$was_enabled = Config::is_enabled();
+		$enable      = isset( $_POST['acfw_enabled'] ) && '1' === $_POST['acfw_enabled']; // phpcs:ignore WordPress.Security.NonceVerification.Missing
+
+		update_option( Config::ENABLED_OPTION, $enable, true );
+
+		if ( $enable ) {
+			// (Re)lock to the current domain whenever we transition to enabled.
+			if ( ! $was_enabled ) {
+				Config::lock_to_current_host();
+			}
+			$this->redirect( $was_enabled ? 'saved' : 'enabled' );
+		}
+
+		$this->redirect( 'disabled' );
+	}
+
+	/**
+	 * admin-post: re-pin the domain lock to the current host.
+	 */
+	public function handle_reconnect(): void {
+		$this->verify( self::RECONNECT_ACTION );
+		Config::lock_to_current_host();
+		$this->redirect( 'reconnected' );
+	}
+
+	/**
+	 * Shared cap + nonce check for the admin-post handlers.
+	 */
+	private function verify( string $action ): void {
+		if ( ! current_user_can( Config::CAP ) ) {
+			wp_die( esc_html__( 'You do not have permission to do this.', 'agent-connector-for-wp' ), '', array( 'response' => 403 ) );
+		}
+		check_admin_referer( $action );
+	}
+
+	/**
+	 * Redirect back to this page with a status notice.
+	 */
+	private function redirect( string $notice ): void {
+		wp_safe_redirect(
+			add_query_arg(
+				array(
+					'page'        => self::MENU_SLUG,
+					'acfw_notice' => $notice,
+				),
+				admin_url( 'admin.php' )
+			)
+		);
+		exit;
+	}
+}

--- a/plugin/src/Plugin.php
+++ b/plugin/src/Plugin.php
@@ -9,6 +9,7 @@ declare( strict_types=1 );
 
 namespace AgentConnectorForWp;
 
+use AgentConnectorForWp\Abilities\AdminLoginAbility;
 use AgentConnectorForWp\Abilities\EnvInspectAbility;
 use AgentConnectorForWp\Abilities\FileDeleteAbility;
 use AgentConnectorForWp\Abilities\FileListAbility;
@@ -19,6 +20,7 @@ use AgentConnectorForWp\Abilities\ProcessExecAbility;
 use AgentConnectorForWp\Abilities\ShellAbility;
 use AgentConnectorForWp\Abilities\WpCliAbility;
 use AgentConnectorForWp\Admin\ConnectPage;
+use AgentConnectorForWp\Services\AdminLoginLink;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -45,11 +47,16 @@ final class Plugin {
 		FileWriteAbility::class,
 		FileListAbility::class,
 		FileDeleteAbility::class,
+		AdminLoginAbility::class,
 	);
 
 	public function register(): void {
 		add_action( 'wp_abilities_api_categories_init', array( $this, 'register_category' ) );
 		add_action( 'wp_abilities_api_init', array( $this, 'register_abilities' ) );
+
+		// Redeem one-time admin login links. Hooked on the front end too — the
+		// browser opening the link is logged out, so it won't reach wp-admin yet.
+		add_action( 'init', array( AdminLoginLink::class, 'maybe_consume' ) );
 
 		if ( is_admin() ) {
 			( new ConnectPage() )->register();

--- a/plugin/src/Services/AdminLoginLink.php
+++ b/plugin/src/Services/AdminLoginLink.php
@@ -1,0 +1,208 @@
+<?php
+/**
+ * Mint and redeem one-time wp-admin login links.
+ *
+ * @package AgentConnectorForWp
+ */
+
+declare( strict_types=1 );
+
+namespace AgentConnectorForWp\Services;
+
+use AgentConnectorForWp\Support\Config;
+use WP_Error;
+use WP_User;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Gives a browser-driving agent (Playwright et al.) a way into wp-admin.
+ *
+ * An agent authenticates to MCP with an application password, not browser
+ * cookies — so it can call abilities but can't open the admin UI. This service
+ * mints a single-use, short-lived URL that, when opened, logs the browser in as
+ * the same super-admin who requested it and drops them at an admin screen.
+ *
+ * Design:
+ *  - Token is random; only its SHA-256 hash is stored (in a transient keyed by
+ *    that hash), so a leaked database row can't be replayed into a session.
+ *  - One-time: the transient is deleted the moment it's redeemed.
+ *  - Short TTL (default 5 min): expiry is the transient's own lifetime.
+ *  - The URL is built from the *current request host*, not home_url(), so the
+ *    party that will open it (a browser inside the same Docker network, reaching
+ *    the site as http://wordpress) actually lands on a reachable host. The
+ *    redemption then logs in and redirects on that same host, keeping the auth
+ *    cookie's host aligned with where the browser is.
+ */
+final class AdminLoginLink {
+
+	/**
+	 * Query var that triggers redemption on the front end.
+	 */
+	public const QUERY_VAR = 'acfw_login';
+
+	/**
+	 * Transient key prefix; the suffix is the token hash.
+	 */
+	private const TRANSIENT_PREFIX = 'acfw_login_';
+
+	public const DEFAULT_TTL = 300;
+	public const MIN_TTL     = 30;
+	public const MAX_TTL     = 900;
+
+	/**
+	 * Create a login link for the given user.
+	 *
+	 * @param int    $user_id     The super-admin to log in as.
+	 * @param string $redirect_to Admin-relative target (e.g. "plugins.php"). Absolute
+	 *                            URLs are rejected to prevent open redirects.
+	 * @param int    $ttl_seconds Lifetime; clamped to [MIN_TTL, MAX_TTL].
+	 * @return array{login_url:string,expires_at:string,expires_in_seconds:int}|WP_Error
+	 */
+	public static function create( int $user_id, string $redirect_to = '', int $ttl_seconds = self::DEFAULT_TTL ) {
+		$user = get_user_by( 'id', $user_id );
+		if ( ! ( $user instanceof WP_User ) || ! $user->exists() ) {
+			return new WP_Error( 'agent_connector_login_no_user', 'Could not resolve the requesting user.', array( 'status' => 400 ) );
+		}
+
+		$ttl  = max( self::MIN_TTL, min( self::MAX_TTL, $ttl_seconds ) );
+		$path = self::sanitize_admin_path( $redirect_to );
+
+		$token = bin2hex( random_bytes( 32 ) );
+		$hash  = hash( 'sha256', $token );
+
+		set_transient(
+			self::TRANSIENT_PREFIX . $hash,
+			array(
+				'user_id'     => $user->ID,
+				'redirect_to' => $path,
+			),
+			$ttl
+		);
+
+		$login_url = add_query_arg( self::QUERY_VAR, $token, self::request_base_url() . '/' );
+
+		return array(
+			'login_url'          => $login_url,
+			'expires_at'         => gmdate( 'c', time() + $ttl ),
+			'expires_in_seconds' => $ttl,
+		);
+	}
+
+	/**
+	 * Front-end hook: if the request carries a valid login token, consume it,
+	 * establish the session, and redirect into wp-admin. No-ops otherwise.
+	 */
+	public static function maybe_consume(): void {
+		if ( empty( $_GET[ self::QUERY_VAR ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			return;
+		}
+
+		$token = sanitize_text_field( wp_unslash( $_GET[ self::QUERY_VAR ] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( ! ctype_xdigit( $token ) ) {
+			self::deny( 'This login link is malformed.' );
+		}
+
+		$hash = hash( 'sha256', $token );
+		$key  = self::TRANSIENT_PREFIX . $hash;
+		$data = get_transient( $key );
+
+		// One-time: delete immediately, before any further checks, so a token
+		// can never be redeemed twice even if a later check fails.
+		delete_transient( $key );
+
+		if ( ! is_array( $data ) || empty( $data['user_id'] ) ) {
+			self::deny( 'This login link is invalid or has expired. Ask the agent to generate a fresh one.' );
+		}
+
+		// Re-check the domain lock at redemption: the site's identity could have
+		// changed between link creation and the click.
+		$lock_reason = Config::lock_mismatch_reason();
+		if ( null !== $lock_reason ) {
+			self::deny( $lock_reason );
+		}
+
+		$user = get_user_by( 'id', (int) $data['user_id'] );
+		if ( ! ( $user instanceof WP_User ) || ! $user->exists() || ! is_super_admin( $user->ID ) ) {
+			self::deny( 'The account this link was issued for is no longer a super admin.' );
+		}
+
+		wp_set_current_user( $user->ID );
+		wp_set_auth_cookie( $user->ID, false );
+
+		$target = self::request_base_url() . '/wp-admin/' . self::sanitize_admin_path( (string) ( $data['redirect_to'] ?? '' ) );
+
+		// wp_safe_redirect() only allows hosts it knows; we redirect to the host
+		// the browser actually used (which may differ from siteurl), so allow it
+		// explicitly for this one redirect.
+		$host = self::request_host();
+		add_filter(
+			'allowed_redirect_hosts',
+			static function ( array $hosts ) use ( $host ): array {
+				$hosts[] = $host;
+				return $hosts;
+			}
+		);
+
+		wp_safe_redirect( $target );
+		exit;
+	}
+
+	/**
+	 * Reject a redemption attempt with a plain, human-readable message (the
+	 * person clicking is a human in a browser, not the agent).
+	 */
+	private static function deny( string $message ): void {
+		wp_die(
+			esc_html( $message ),
+			esc_html__( 'Agent Connector for WP', 'agent-connector-for-wp' ),
+			array( 'response' => 403 )
+		);
+	}
+
+	/**
+	 * scheme://host (with port) of the current request — the host the caller
+	 * used to reach this site.
+	 */
+	private static function request_base_url(): string {
+		$scheme = is_ssl() ? 'https' : 'http';
+		return $scheme . '://' . self::request_host();
+	}
+
+	/**
+	 * Host (including any :port) from the current request, fingerprint-safe.
+	 */
+	private static function request_host(): string {
+		$host = isset( $_SERVER['HTTP_HOST'] ) ? wp_unslash( $_SERVER['HTTP_HOST'] ) : '';
+		// Allow only the characters legal in a host:port; drop anything else.
+		$host = preg_replace( '/[^A-Za-z0-9.\-:\[\]]/', '', (string) $host );
+		if ( '' === (string) $host ) {
+			// Fall back to the declared home host if the request has no Host.
+			$host = Config::declared_host();
+		}
+		return (string) $host;
+	}
+
+	/**
+	 * Reduce a caller-supplied redirect target to a safe admin-relative path.
+	 *
+	 * Rejects absolute and protocol-relative URLs (open-redirect guard) and
+	 * strips a leading "wp-admin/" so callers can pass either form.
+	 */
+	private static function sanitize_admin_path( string $redirect_to ): string {
+		$redirect_to = trim( $redirect_to );
+
+		if ( '' === $redirect_to ) {
+			return 'index.php';
+		}
+
+		// Anything that looks like it points off-path becomes the dashboard.
+		if ( false !== strpos( $redirect_to, '://' ) || 0 === strpos( $redirect_to, '//' ) || 0 === strpos( $redirect_to, '/' ) ) {
+			return 'index.php';
+		}
+
+		$redirect_to = preg_replace( '#^wp-admin/#', '', $redirect_to );
+
+		return '' === $redirect_to ? 'index.php' : ltrim( $redirect_to, '/' );
+	}
+}

--- a/plugin/src/Services/AuditLogger.php
+++ b/plugin/src/Services/AuditLogger.php
@@ -63,8 +63,24 @@ final class AuditLogger {
 	 */
 	public static function wrap( string $ability, callable $handler, ?callable $summarizer = null ): callable {
 		return static function ( $input = array() ) use ( $ability, $handler, $summarizer ) {
-			$input   = is_array( $input ) ? $input : array();
-			$start   = microtime( true );
+			$input = is_array( $input ) ? $input : array();
+			$start = microtime( true );
+
+			// Domain lock: this is the single chokepoint every ability runs
+			// through, so enforcement lives here rather than in each handler. On
+			// a mismatch we never invoke the handler — we return an
+			// agent-actionable error and still record the blocked attempt.
+			$lock_reason = Config::lock_mismatch_reason();
+			if ( null !== $lock_reason ) {
+				$summary = $summarizer ? (array) $summarizer( $input ) : array();
+				self::log( $ability, $summary, 'error', 0 );
+				return new \WP_Error(
+					'agent_connector_domain_locked',
+					$lock_reason,
+					array( 'status' => 403 )
+				);
+			}
+
 			$result  = $handler( $input );
 			$status  = is_wp_error( $result ) ? 'error' : 'ok';
 			$summary = $summarizer ? (array) $summarizer( $input ) : array();

--- a/plugin/src/Support/Config.php
+++ b/plugin/src/Support/Config.php
@@ -14,9 +14,10 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Centralizes the mandatory opt-in gates and tunables.
  *
- * The plugin is dangerous by design, so nothing initializes unless the operator
- * has explicitly flicked the toggle on the Settings screen. There is
- * intentionally no environment heuristic: off means off until a human says yes.
+ * Nothing initializes unless the operator flicked the Enable toggle on the
+ * Settings screen. As a second safety gate, if the site reports a production
+ * environment type, enabling alone is not enough — the operator must also tick
+ * an explicit production-override box. Off means off until a human says yes.
  */
 final class Config {
 
@@ -28,6 +29,14 @@ final class Config {
 	public const ENABLED_OPTION = 'agent_connector_for_wp_enabled';
 
 	/**
+	 * Option storing the explicit "run on production anyway" override (boolean).
+	 *
+	 * Only consulted when the site reports a production environment type; on
+	 * non-production environments the Enable toggle alone is sufficient.
+	 */
+	public const PRODUCTION_OVERRIDE_OPTION = 'agent_connector_for_wp_allow_production';
+
+	/**
 	 * Option storing the host the plugin was last enabled / reconnected on.
 	 *
 	 * This is the domain lock: abilities refuse to run if the site's declared
@@ -37,19 +46,57 @@ final class Config {
 	public const LOCKED_HOST_OPTION = 'agent_connector_for_wp_locked_host';
 
 	/**
-	 * Master switch. The plugin does nothing unless the operator turned the
-	 * Settings toggle on.
+	 * The Enable toggle (box 1). This is the operator's intent to turn the
+	 * plugin on; whether it actually boots also depends on the environment gate.
 	 */
 	public static function is_enabled(): bool {
 		return (bool) get_option( self::ENABLED_OPTION, false );
 	}
 
 	/**
-	 * Master boot decision. With the production heuristic gone this is simply
-	 * "did a human explicitly enable it".
+	 * Whether this site reports a non-production environment type.
+	 *
+	 * wp_get_environment_type() is one of 'local', 'development', 'staging', or
+	 * 'production', defaulting to 'production' when WP_ENVIRONMENT_TYPE is unset.
+	 * Anything other than 'production' is treated as safe to enable without the
+	 * extra override — and a site that never configured its environment type is
+	 * therefore (correctly) treated as production.
+	 */
+	public static function is_non_production_env(): bool {
+		if ( ! function_exists( 'wp_get_environment_type' ) ) {
+			return false; // Can't prove it's non-production → require the override.
+		}
+		return 'production' !== wp_get_environment_type();
+	}
+
+	/**
+	 * The production-override toggle (box 2). Only meaningful on production.
+	 */
+	public static function production_override_enabled(): bool {
+		return (bool) get_option( self::PRODUCTION_OVERRIDE_OPTION, false );
+	}
+
+	/**
+	 * Master boot decision. Two gates:
+	 *   1. The operator enabled the plugin (box 1), AND
+	 *   2. the environment is non-production, OR the operator explicitly ticked
+	 *      the production override (box 2).
 	 */
 	public static function can_boot(): bool {
-		return self::is_enabled();
+		if ( ! self::is_enabled() ) {
+			return false;
+		}
+		if ( self::is_non_production_env() ) {
+			return true;
+		}
+		return self::production_override_enabled();
+	}
+
+	/**
+	 * Enabled (box 1) but held back by the production gate (no override).
+	 */
+	public static function is_blocked_by_production(): bool {
+		return self::is_enabled() && ! self::is_non_production_env() && ! self::production_override_enabled();
 	}
 
 	/**
@@ -173,8 +220,8 @@ final class Config {
 	}
 
 	/**
-	 * Admin notice shown when the plugin is installed but switched off, pointing
-	 * the operator at the Settings screen (which is always reachable).
+	 * Admin notice shown when the plugin is installed but not currently active,
+	 * pointing the operator at the always-reachable Settings screen.
 	 */
 	public static function render_gate_notice(): void {
 		if ( ! current_user_can( self::CAP ) ) {
@@ -183,14 +230,26 @@ final class Config {
 
 		$settings_url = admin_url( 'admin.php?page=agent-connector-for-wp' );
 
+		if ( self::is_blocked_by_production() ) {
+			$message = sprintf(
+				'It is enabled, but this is a <code>production</code> environment, so it stays inactive until you confirm the production override on the <a href="%s">Settings screen</a>.',
+				esc_url( $settings_url )
+			);
+		} else {
+			$message = sprintf(
+				'Enable it on the <a href="%s">Settings screen</a>.',
+				esc_url( $settings_url )
+			);
+		}
+
 		printf(
-			'<div class="notice notice-warning"><p><strong>Agent Connector for WP</strong> is installed but switched off. %s</p></div>',
+			'<div class="notice notice-warning"><p><strong>Agent Connector for WP</strong> is installed but inactive. %s</p></div>',
 			wp_kses(
-				sprintf(
-					'Enable it on the <a href="%s">Settings screen</a>.',
-					esc_url( $settings_url )
-				),
-				array( 'a' => array( 'href' => array() ) )
+				$message,
+				array(
+					'a'    => array( 'href' => array() ),
+					'code' => array(),
+				)
 			)
 		);
 	}

--- a/plugin/src/Support/Config.php
+++ b/plugin/src/Support/Config.php
@@ -14,44 +14,123 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Centralizes the mandatory opt-in gates and tunables.
  *
- * The plugin is dangerous by design, so nothing initializes unless the
- * operator has explicitly defined the enabling constants (typically in
- * wp-config.php).
+ * The plugin is dangerous by design, so nothing initializes unless the operator
+ * has explicitly flicked the toggle on the Settings screen. There is
+ * intentionally no environment heuristic: off means off until a human says yes.
  */
 final class Config {
 
 	public const CAP = 'manage_options';
 
 	/**
-	 * Master switch. The plugin does nothing unless this is true.
+	 * Option storing the Settings-screen enable toggle (boolean).
+	 */
+	public const ENABLED_OPTION = 'agent_connector_for_wp_enabled';
+
+	/**
+	 * Option storing the host the plugin was last enabled / reconnected on.
+	 *
+	 * This is the domain lock: abilities refuse to run if the site's declared
+	 * home host no longer matches this value. Empty means "never locked", in
+	 * which case the lock is inert.
+	 */
+	public const LOCKED_HOST_OPTION = 'agent_connector_for_wp_locked_host';
+
+	/**
+	 * Master switch. The plugin does nothing unless the operator turned the
+	 * Settings toggle on.
 	 */
 	public static function is_enabled(): bool {
-		return defined( 'AGENT_CONNECTOR_FOR_WP_ENABLED' ) && true === AGENT_CONNECTOR_FOR_WP_ENABLED;
+		return (bool) get_option( self::ENABLED_OPTION, false );
 	}
 
 	/**
-	 * Production is blocked unless explicitly overridden.
-	 */
-	public static function allow_production(): bool {
-		return defined( 'AGENT_CONNECTOR_FOR_WP_ALLOW_PRODUCTION' ) && true === AGENT_CONNECTOR_FOR_WP_ALLOW_PRODUCTION;
-	}
-
-	public static function is_production(): bool {
-		return function_exists( 'wp_get_environment_type' ) && 'production' === wp_get_environment_type();
-	}
-
-	/**
-	 * Master boot decision: enabled, not blocked by the production guard, and
-	 * the Abilities API is actually present to register against.
+	 * Master boot decision. With the production heuristic gone this is simply
+	 * "did a human explicitly enable it".
 	 */
 	public static function can_boot(): bool {
-		if ( ! self::is_enabled() ) {
-			return false;
+		return self::is_enabled();
+	}
+
+	/**
+	 * The site's *declared* home URL, read straight from the options table.
+	 *
+	 * We deliberately bypass get_option()/home_url(), because the
+	 * _config_wp_home filter substitutes the WP_HOME constant when it is defined
+	 * — and dev environments (e.g. the Docker sandbox this plugin targets) define
+	 * WP_HOME dynamically from $_SERVER['HTTP_HOST'] per request, so home_url()
+	 * returns whatever host the caller used. That makes it useless as an identity
+	 * for the domain lock: the agent (http://wordpress) and the operator's
+	 * browser (http://localhost:PORT) would see different values for one install.
+	 * The stored option is the single stable identity, set once at install.
+	 */
+	public static function declared_home_url(): string {
+		global $wpdb;
+
+		$value = $wpdb->get_var( // phpcs:ignore WordPress.DB.DirectDatabaseQuery
+			$wpdb->prepare( "SELECT option_value FROM {$wpdb->options} WHERE option_name = %s LIMIT 1", 'home' )
+		);
+
+		if ( ! is_string( $value ) || '' === $value ) {
+			// Fallback for unusual setups (e.g. constant-defined options table).
+			$value = (string) get_option( 'home' );
 		}
-		if ( self::is_production() && ! self::allow_production() ) {
-			return false;
+
+		return (string) $value;
+	}
+
+	/**
+	 * Host component of the declared home URL (no scheme, no port-stripping).
+	 */
+	public static function declared_host(): string {
+		$host = wp_parse_url( self::declared_home_url(), PHP_URL_HOST );
+		return is_string( $host ) ? $host : '';
+	}
+
+	/**
+	 * The host the domain lock is pinned to, or '' if never locked.
+	 */
+	public static function locked_host(): string {
+		return (string) get_option( self::LOCKED_HOST_OPTION, '' );
+	}
+
+	/**
+	 * Pin (or re-pin) the domain lock to the site's current declared host.
+	 *
+	 * Called whenever the operator enables the plugin or clicks "Reconnect".
+	 */
+	public static function lock_to_current_host(): void {
+		update_option( self::LOCKED_HOST_OPTION, self::declared_host(), false );
+	}
+
+	/**
+	 * Whether the domain lock is satisfied. True when no lock is set, or when the
+	 * pinned host still matches the declared host.
+	 */
+	public static function domain_lock_ok(): bool {
+		return null === self::lock_mismatch_reason();
+	}
+
+	/**
+	 * Agent-actionable explanation of a domain-lock mismatch, or null when the
+	 * lock is satisfied (or inert).
+	 *
+	 * The message is written for the agent calling an ability over MCP: it tells
+	 * the agent exactly which human action unblocks it.
+	 */
+	public static function lock_mismatch_reason(): ?string {
+		$locked   = self::locked_host();
+		$declared = self::declared_host();
+
+		if ( '' === $locked || $locked === $declared ) {
+			return null;
 		}
-		return true;
+
+		return sprintf(
+			'Agent Connector for WP is domain-locked. It was enabled on "%1$s" but this site now reports its home as "%2$s", so all abilities are blocked. An administrator must open wp-admin → Agent Connector for WP → Settings and click "Reconnect to this domain" to re-enable abilities here.',
+			$locked,
+			'' === $declared ? '(unknown)' : $declared
+		);
 	}
 
 	/**
@@ -94,24 +173,25 @@ final class Config {
 	}
 
 	/**
-	 * Admin notice explaining which gate kept the plugin inert.
+	 * Admin notice shown when the plugin is installed but switched off, pointing
+	 * the operator at the Settings screen (which is always reachable).
 	 */
 	public static function render_gate_notice(): void {
-		if ( ! current_user_can( 'manage_options' ) ) {
+		if ( ! current_user_can( self::CAP ) ) {
 			return;
 		}
 
-		if ( ! self::is_enabled() ) {
-			$reason = "Define <code>AGENT_CONNECTOR_FOR_WP_ENABLED</code> as <code>true</code> in wp-config.php to enable it.";
-		} elseif ( self::is_production() && ! self::allow_production() ) {
-			$reason = "The environment type is <code>production</code>. Set a non-production <code>WP_ENVIRONMENT_TYPE</code>, or define <code>AGENT_CONNECTOR_FOR_WP_ALLOW_PRODUCTION</code> as <code>true</code> to override (not recommended).";
-		} else {
-			return;
-		}
+		$settings_url = admin_url( 'admin.php?page=agent-connector-for-wp' );
 
 		printf(
-			'<div class="notice notice-warning"><p><strong>Agent Connector for WP</strong> is installed but inactive. %s</p></div>',
-			wp_kses( $reason, array( 'code' => array() ) )
+			'<div class="notice notice-warning"><p><strong>Agent Connector for WP</strong> is installed but switched off. %s</p></div>',
+			wp_kses(
+				sprintf(
+					'Enable it on the <a href="%s">Settings screen</a>.',
+					esc_url( $settings_url )
+				),
+				array( 'a' => array( 'href' => array() ) )
+			)
 		);
 	}
 }

--- a/plugin/src/Support/Connection.php
+++ b/plugin/src/Support/Connection.php
@@ -121,7 +121,9 @@ final class Connection {
 				'available tools to confirm it works. Use the "discover-abilities" tool to see what this',
 				'site can do and "execute-ability" to run one — including agent-connector-for-wp/shell-exec,',
 				'agent-connector-for-wp/php-eval, and the file-read/write/list/delete abilities, which give you',
-				'shell, PHP, and filesystem access on the server.',
+				'shell, PHP, and filesystem access on the server. To drive the WordPress admin in a browser,',
+				'run agent-connector-for-wp/create-admin-login-link and open the returned URL: it logs the',
+				'browser into wp-admin once, without a username or password.',
 			)
 		);
 


### PR DESCRIPTION
## Summary

Replaces the wp-config gating with a UI-driven enable model and adds the operational pieces a browser-driving agent needs. Everything was verified end-to-end against the running sandbox.

### Enable model
- The plugin is off until a human ticks **Enable** on a new, always-registered **Settings** screen. The `AGENT_CONNECTOR_FOR_WP_ENABLED` define and the `wp_get_environment_type()` production heuristic are removed.
- **Two gates** (`Config::can_boot()`): box 1 (Enable) must be on **and** the environment must be non-production **or** box 2 (Production override) explicitly ticked. `is_non_production_env()` treats anything other than `production` as safe — so an unconfigured site (which WordPress defaults to `production`) correctly requires the override.
- The danger warning lives only on the production-override box, which appears only on a `production` environment type. On local/development/staging, Enable alone activates it with no scary copy.

### Domain lock
- On enable (or **Reconnect to this domain**) the site's declared home host is recorded. Abilities then refuse to run if the host changes, returning an agent-actionable `WP_Error`, so a cloned database can't silently grant access on another domain. Enforced at the single `AuditLogger::wrap()` chokepoint.
- Compares the **raw stored `home` option** (read via `$wpdb`, bypassing the `_config_wp_home` filter) rather than `home_url()`, because dev setups can define `WP_HOME` dynamically per request — `home_url()` would false-lock there.

### Admin login link
- New `create-admin-login-link` ability mints a one-time, short-lived (5-min) URL that logs a browser into wp-admin as the requesting super admin — for agents that hold only an application password. Token stored as a SHA-256 hash in a transient; URL and post-login redirect built from the request host so an in-network (e.g. Dockerized Playwright) browser can reach them.

ConnectPage becomes a submenu under the Settings page; `readme.txt` / `README.md` updated.

## Verification

| Env | Enable | Override | Result |
|---|---|---|---|
| local | yes | – | active |
| production | yes | no | blocked (`blocked_by_production`) |
| production | yes | yes | active |

- Login link: HTTP redemption via `http://wordpress/` → 302 to `/wp-admin/` on the request host, auth cookies set, lands in wp-admin (200, no canonical bounce), second use → 403 (one-time).
- Domain lock: mismatch blocks at `wrap()` without invoking the handler (403); reconnect clears it.
- Settings UI renders correctly in both local (no production box) and production (override box + danger warning) contexts.

## Follow-up (separate repo, not in this PR)

The sandbox repo's `install-agent-connector.sh` enables via `wp config set AGENT_CONNECTOR_FOR_WP_ENABLED true`, which this PR turns into a no-op. When a release containing this change ships, that script needs to switch to `wp option update agent_connector_for_wp_enabled 1` (and bump its pinned zip) in the same change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)