### PR TITLE
docs: document PR-title release conventions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,28 @@
+# Notes for agents working in this repo
+
+Read [`CONTRIBUTING.md`](CONTRIBUTING.md) before opening a PR.
+
+## PR / commit titles drive releases
+
+Merging a PR to `master` (when it touches `plugin/**`) automatically publishes a
+new GitHub Release, and the **PR title** decides the version bump (Conventional
+Commits):
+
+- breaking change (`type!:`, or `BREAKING CHANGE` in the body) → **major**
+- `fix: …` → **patch**
+- anything else (`feat:`, unprefixed, `chore:`, `docs:`, …) → **minor** (the default)
+
+Use `fix:` only for real bug fixes; everything else becomes a minor/feature
+release. Title PRs accordingly.
+
+## Don't touch the version by hand
+
+The release bot owns the version in `plugin/agent-connector-for-wp.php`
+(`Version:` + `AGENT_CONNECTOR_FOR_WP_VERSION`) and `plugin/readme.txt`
+(`Stable tag:`). Leave them alone — it bumps them on release with `[skip ci]`.
+
+## Don't `wp plugin install --force` over the symlink
+
+The live plugin is a symlink to `plugin/`; a forced install deletes the link
+target (your working-tree source). To test a built zip, inspect it or extract it
+under a different slug.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,47 @@
+# Contributing
+
+## Releases are automatic — your PR title sets the version
+
+Every merge to `master` that touches `plugin/**` automatically cuts a new
+versioned GitHub Release (see [`.github/workflows/auto-release.yml`](.github/workflows/auto-release.yml)).
+The workflow reads the **merged PR's title** as a [Conventional Commit](https://www.conventionalcommits.org/)
+and uses it to decide the version bump, then syncs the version into the plugin
+header / `readme.txt`, tags it, builds the vendored zip, and publishes the
+release.
+
+**So: title every PR like a conventional commit.** That title is the one that
+matters — branch commit messages are not what drives the bump.
+
+| PR title | Bump | Example |
+| --- | --- | --- |
+| breaking change (`type!:` prefix, or `BREAKING CHANGE` in the body) | **major** | `feat!: drop the enable constant` → `1.4.2 → 2.0.0` |
+| `fix: …` | **patch** | `fix: stop double-escaping the login URL` → `1.4.2 → 1.4.3` |
+| anything else — `feat:`, no prefix, `chore:`, `docs:`, `refactor:`, … | **minor** (treated as a feature) | `feat: add domain lock` / `Settings screen redesign` → `1.4.2 → 1.5.0` |
+
+The default is **minor**: if a title isn't clearly a `fix:` or a breaking
+change, it's treated as a feature. Reserve `fix:` for actual bug fixes so they
+land as patch releases.
+
+### Notes
+
+- **Don't hand-edit the version** in `plugin/agent-connector-for-wp.php`
+  (`Version:` header and `AGENT_CONNECTOR_FOR_WP_VERSION`) or `readme.txt`
+  (`Stable tag:`). The release bot owns those and commits the bump with
+  `[skip ci]`. Editing them yourself just creates conflicts.
+- **Scope:** releases fire only when `plugin/**` changes. A `site/`- or
+  root-docs-only merge won't cut a release.
+- **Need a specific bump or a re-run?** Run the **Auto release on merge**
+  workflow manually (Actions → Run workflow) and pick the `bump` input, or push
+  a `vX.Y.Z` tag yourself — [`release.yml`](.github/workflows/release.yml) builds
+  and publishes any manually pushed tag.
+
+## Local development
+
+See [`README.md`](README.md) for the full setup. In short: `composer install`
+in `plugin/`, symlink `plugin/` into a WordPress install with `bin/install.sh`,
+then enable it from **Agent Connector for WP → Settings** in wp-admin.
+
+> ⚠️ The plugin is usually symlinked into `wp-content/plugins`. Never run
+> `wp plugin install <zip> --force` over that symlink — WP deletes the link
+> target first, which wipes your working-tree source. To test a built zip,
+> inspect it or extract it under a different plugin slug.


### PR DESCRIPTION
Adds `CONTRIBUTING.md` and `CLAUDE.md` so contributors (and the agent working on the repo) know how to title PRs, since the **PR title drives the automatic version bump**.

- **CONTRIBUTING.md** — canonical: the Conventional-Commit bump table (breaking → major, `fix:` → patch, everything else → minor/feat default), "don't hand-edit the bot-owned version", path scoping, and the manual-bump escape hatch.
- **CLAUDE.md** — short version Claude Code auto-loads, pointing at CONTRIBUTING.md.
- Both also flag the `wp plugin install --force`-over-symlink hazard.

These are root-level docs (not `plugin/**`), so merging this **won't** cut a release — which doubles as a demonstration that the release scoping works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)