### PR TITLE
Sandbox, GitHub updater, third-party ability API, and ability-pack directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ Thumbs.db
 *.swp
 .idea/
 .vscode/
+
+# Local agent worktrees / session state
+.claude/

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -136,6 +136,32 @@ define( 'AGENT_CONNECTOR_FOR_WP_AUDIT_LOG', '/path/to/audit.log' );
 { "command": "plugin list --status=active --format=json" }
 ```
 
+## Register your own abilities
+
+Third-party plugins can add abilities that are exposed over this plugin's MCP
+server and **automatically protected by its auth, domain lock, and audit log** —
+the companion plugin writes no permission or security code. Use the public API:
+
+```php
+add_action( 'wp_abilities_api_init', function () {
+    if ( ! function_exists( 'agent_connector_for_wp_register_ability' ) ) {
+        return;
+    }
+    agent_connector_for_wp_register_ability( 'my-plugin/do-thing', array(
+        'label'            => 'Do Thing',
+        'description'      => 'Does the thing.',
+        'category'         => 'my-plugin', // register it on wp_abilities_api_categories_init
+        'input_schema'     => array( 'type' => 'object', 'properties' => array(), 'additionalProperties' => false ),
+        'output_schema'    => array( 'type' => 'object', 'properties' => array( 'message' => array( 'type' => 'string' ) ) ),
+        'execute_callback' => fn( array $input ) => array( 'message' => 'done' ),
+    ) );
+} );
+```
+
+Full guide, schema conventions, audit-redaction contract, and the companion
+"ability pack" plugin convention: **[`docs/registering-abilities.md`](docs/registering-abilities.md)**.
+A runnable reference pack lives in [`examples/acfw-ability-pack-hello/`](examples/acfw-ability-pack-hello/).
+
 ## Philosophy
 
 > Trusted agents in trusted environments should have root-equivalent operational capability.

--- a/plugin/agent-connector-for-wp.php
+++ b/plugin/agent-connector-for-wp.php
@@ -97,6 +97,8 @@ add_action(
 		// dangerous; the gates below still guard the MCP server and abilities.
 		if ( is_admin() ) {
 			( new Admin\ConnectionPage() )->register();
+			// Read-only browser of available companion "ability pack" plugins.
+			( new Admin\DirectoryPage() )->register();
 		}
 
 		if ( ! Support\Config::can_boot() ) {

--- a/plugin/agent-connector-for-wp.php
+++ b/plugin/agent-connector-for-wp.php
@@ -105,6 +105,11 @@ add_action(
 			return;
 		}
 
+		// Auto-load AI-written PHP "plugins" from the sandbox directory, with
+		// crash recovery (safe mode) so a fatal in generated code can't take the
+		// site down. See Services\SandboxLoader.
+		( new Services\SandboxLoader() )->run();
+
 		/**
 		 * Ensure the MCP Adapter is running.
 		 *

--- a/plugin/agent-connector-for-wp.php
+++ b/plugin/agent-connector-for-wp.php
@@ -128,3 +128,73 @@ add_action(
 		}
 	}
 );
+
+/**
+ * Self-update from GitHub Releases via yahnis-elsts/plugin-update-checker.
+ *
+ * We pull updates straight from this plugin's GitHub repo instead of the
+ * wordpress.org directory (the plugin is intentionally dev-only and is not, and
+ * will not be, hosted there). The library is bundled through the same Jetpack
+ * Autoloader as the rest of vendor/: its loader (load-v5p7.php) is registered in
+ * the autoloader's filemap, so YahnisElsts\PluginUpdateChecker\v5\PucFactory is
+ * available once vendor/ is present — no separate require needed here.
+ *
+ * IMPORTANT — release assets, not the source tarball:
+ * enableReleaseAssets() makes the checker install the built ZIP attached to each
+ * GitHub Release (which bundles vendor/) rather than GitHub's auto-generated
+ * source tarball. The source tarball would be BROKEN as an update because
+ * vendor/ is gitignored, so it ships without the Jetpack autoloader or the MCP
+ * adapter and the plugin would fatal on load. The release ZIP is produced by
+ * .github/workflows/auto-release.yml / release.yml.
+ *
+ * Maintainer action required for updates to flow: cut a GitHub Release on a
+ * vX.Y.Z tag with the built `agent-connector-for-wp.zip` attached as a release
+ * asset. The auto-release workflow does this automatically on merge to master.
+ *
+ * The repo is assumed PUBLIC. If it's made private, supply a GitHub token via
+ * the `agent_connector_for_wp_github_auth_token` filter (or define the
+ * AGENT_CONNECTOR_FOR_WP_GITHUB_TOKEN constant). No token is hardcoded.
+ *
+ * Guarded to admin context: update checks only need to run in wp-admin, never on
+ * every front-end request.
+ */
+add_action(
+	'admin_init',
+	static function (): void {
+		$factory = '\\YahnisElsts\\PluginUpdateChecker\\v5\\PucFactory';
+		if ( ! class_exists( $factory ) ) {
+			// vendor/ missing (e.g. a source checkout without `composer install`).
+			return;
+		}
+
+		$update_checker = $factory::buildUpdateChecker(
+			'https://github.com/soflyy/agent-connector-for-wp/',
+			AGENT_CONNECTOR_FOR_WP_FILE,
+			'agent-connector-for-wp'
+		);
+
+		// Default branch holding the stable tags/releases.
+		$update_checker->setBranch( 'master' );
+
+		/**
+		 * GitHub auth token for the update checker.
+		 *
+		 * The repo is public, so this is empty by default. To support a private
+		 * repo later, return a token here (or define
+		 * AGENT_CONNECTOR_FOR_WP_GITHUB_TOKEN). Never hardcode a token in source.
+		 *
+		 * @param string $token GitHub personal access token. Empty for public repos.
+		 */
+		$github_token = (string) apply_filters(
+			'agent_connector_for_wp_github_auth_token',
+			defined( 'AGENT_CONNECTOR_FOR_WP_GITHUB_TOKEN' ) ? (string) AGENT_CONNECTOR_FOR_WP_GITHUB_TOKEN : ''
+		);
+		if ( '' !== $github_token ) {
+			$update_checker->setAuthentication( $github_token );
+		}
+
+		// Install the built release ZIP (with bundled vendor/) attached to each
+		// GitHub Release — NOT the source tarball, which lacks vendor/.
+		$update_checker->getVcsApi()->enableReleaseAssets();
+	}
+);

--- a/plugin/agent-connector-for-wp.php
+++ b/plugin/agent-connector-for-wp.php
@@ -83,6 +83,17 @@ if ( ! $agent_connector_for_wp_has_vendor ) {
 unset( $agent_connector_for_wp_has_vendor );
 
 /**
+ * Load the public ability-registration API (plain functions, global namespace).
+ *
+ * This is a functions file, not a PSR-4 class, so it is required explicitly
+ * rather than autoloaded. It is loaded unconditionally and early so a companion
+ * "ability pack" plugin can call agent_connector_for_wp_register_ability() the
+ * moment this plugin's file has run, regardless of the enable gates below — the
+ * gates still decide whether the MCP server actually exposes anything.
+ */
+require_once AGENT_CONNECTOR_FOR_WP_DIR . 'src/api.php';
+
+/**
  * Boot the plugin once WordPress is loaded.
  *
  * The plugin is inert unless the operator has explicitly switched it on from the
@@ -120,6 +131,13 @@ add_action(
 		if ( class_exists( \WP\MCP\Core\McpAdapter::class ) ) {
 			\WP\MCP\Core\McpAdapter::instance();
 		}
+
+		// Security backstop: force our auth + domain-lock + audit onto EVERY
+		// ability the MCP server will expose (mcp.public), no matter who
+		// registered it — including raw third-party registrations that ship
+		// their own (or no) permission callback. Hooks the core
+		// wp_register_ability_args filter; see Support\Governance.
+		Support\Governance::register();
 
 		// The plugin's own (built-in) abilities are opt-in and off by default;
 		// register them only when the operator has turned them on.

--- a/plugin/composer.json
+++ b/plugin/composer.json
@@ -8,7 +8,8 @@
 	"require": {
 		"php": ">=8.1",
 		"automattic/jetpack-autoloader": "^5.0",
-		"wordpress/mcp-adapter": "^0.5"
+		"wordpress/mcp-adapter": "^0.5",
+		"yahnis-elsts/plugin-update-checker": "^5.7"
 	},
 	"autoload": {
 		"psr-4": {

--- a/plugin/composer.lock
+++ b/plugin/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b6b9c004fe67fdd7731454ae8af21bd1",
+    "content-hash": "9b814200deeda4b1fd05c72c403eccf9",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -197,6 +197,56 @@
                 "source": "https://github.com/WordPress/php-mcp-schema/tree/v0.1.1"
             },
             "time": "2026-04-10T19:35:16+00:00"
+        },
+        {
+            "name": "yahnis-elsts/plugin-update-checker",
+            "version": "v5.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/YahnisElsts/plugin-update-checker.git",
+                "reference": "275a96a2a18d03c34c87f35cb68673c8c49ac3b1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/YahnisElsts/plugin-update-checker/zipball/275a96a2a18d03c34c87f35cb68673c8c49ac3b1",
+                "reference": "275a96a2a18d03c34c87f35cb68673c8c49ac3b1",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "php": ">=5.6.20"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "load-v5p7.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Yahnis Elsts",
+                    "email": "whiteshadow@w-shadow.com",
+                    "homepage": "https://w-shadow.com/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A custom update checker for WordPress plugins and themes. Useful if you can't host your plugin in the official WP repository but still want it to support automatic updates.",
+            "homepage": "https://github.com/YahnisElsts/plugin-update-checker/",
+            "keywords": [
+                "automatic updates",
+                "plugin updates",
+                "theme updates",
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/YahnisElsts/plugin-update-checker/issues",
+                "source": "https://github.com/YahnisElsts/plugin-update-checker/tree/v5.7"
+            },
+            "time": "2026-05-26T12:48:45+00:00"
         }
     ],
     "packages-dev": [],

--- a/plugin/docs/directory-schema.md
+++ b/plugin/docs/directory-schema.md
@@ -33,11 +33,11 @@ The client normalizes both to the same internal list.
 
 ## Entry object
 
-| Field               | Required | Type   | Notes |
-| ------------------- | :------: | ------ | ----- |
-| `host_plugin_slug`  | **yes**  | string | The host WP plugin this pack targets. Either a full plugin file (`woocommerce/woocommerce.php`) or a bare folder slug (`woocommerce`). Matching tolerates both forms. |
-| `ability_pack_name` | **yes**  | string | Human-readable name of the ability pack. |
-| `host_plugin_name`  | no       | string | Display name of the host plugin (the installed plugin's own name is preferred when present). |
+| Field                | Required | Type   | Notes |
+| -------------------- | :------: | ------ | ----- |
+| `target_plugin`      | **yes**  | string | The WP plugin this pack extends — the **join key**. Either a full plugin file (`woocommerce/woocommerce.php`) or a bare folder slug (`woocommerce`). Matching tolerates both forms. This is the same value the pack declares in its `Agent Connector Target:` header. |
+| `ability_pack_name`  | **yes**  | string | Human-readable name of the ability pack. |
+| `target_plugin_name` | no       | string | Display name of the target plugin (the installed plugin's own name is preferred when present). |
 | `ability_pack_slug` | no       | string | The companion plugin's own slug (`folder/file.php` or folder). When given, the client also reports whether the pack itself is already installed/active. |
 | `source_url`        | no       | string | Where to get the pack (GitHub repo, wp.org page, etc.). Rendered as a link. |
 | `description`       | no       | string | One-line description shown in the table. |
@@ -48,7 +48,7 @@ trimmed; non-string values are coerced to empty strings.
 
 ## Matching behavior
 
-For each entry whose `host_plugin_slug` resolves to an **installed** plugin
+For each entry whose `target_plugin` resolves to an **installed** plugin
 (via `get_plugins()`), the UI shows a row with the installed plugin name, the
 ability pack (linked to `source_url`), and a status:
 
@@ -61,9 +61,11 @@ plugins (e.g. `hello.php` ⇄ `hello`).
 
 ## Companion-plugin targeting convention
 
-This directory keys each pack by the **host WP plugin** it extends
-(`host_plugin_slug`). That should line up with whatever convention the
-ability-API side uses to declare which host plugin a companion targets — when
-reconciling, treat `host_plugin_slug` as the join key.
+This directory keys each pack by the **WP plugin it extends** — the `target_plugin`
+field. That is the single join key shared with the ability-API side: a companion
+"ability pack" declares the same value in its `Agent Connector Target:` plugin
+header (see [registering-abilities.md](registering-abilities.md)). A directory
+entry's `target_plugin` and a pack's `Agent Connector Target:` header must match
+for the pack to surface against an installed plugin.
 
 See [`directory.json`](directory.json) for a working sample.

--- a/plugin/docs/directory-schema.md
+++ b/plugin/docs/directory-schema.md
@@ -1,0 +1,69 @@
+# Ability-Pack Directory Schema
+
+Agent Connector for WP fetches a remote JSON **directory** of companion "ability
+pack" plugins and matches it against the plugins installed on a site, so an admin
+can see which of their plugins have an available ability pack.
+
+- **Default URL:** `https://raw.githubusercontent.com/soflyy/agent-connector-for-wp-directory/main/directory.json`
+  (a **placeholder** — there is no live endpoint yet; point it at the real one).
+- **Override filter:** `agent_connector_for_wp_directory_url`
+  ```php
+  add_filter( 'agent_connector_for_wp_directory_url', fn() => 'https://example.com/directory.json' );
+  ```
+- **Caching:** fetched with `wp_remote_get` (5s timeout) and cached in the
+  `agent_connector_for_wp_directory_cache` transient for 12 hours. On a fetch
+  failure the last cached copy is reused (flagged "stale"); with no cache at all
+  the UI shows a clean "directory unavailable" state. A manual **Refresh now**
+  button busts the cache.
+
+## Shape
+
+Two accepted top-level forms; pick whichever you like:
+
+1. A bare JSON **array** of entry objects, or
+2. A JSON **object** with an `entries` array (room for future top-level metadata):
+
+```json
+{
+  "entries": [ /* entry objects */ ]
+}
+```
+
+The client normalizes both to the same internal list.
+
+## Entry object
+
+| Field               | Required | Type   | Notes |
+| ------------------- | :------: | ------ | ----- |
+| `host_plugin_slug`  | **yes**  | string | The host WP plugin this pack targets. Either a full plugin file (`woocommerce/woocommerce.php`) or a bare folder slug (`woocommerce`). Matching tolerates both forms. |
+| `ability_pack_name` | **yes**  | string | Human-readable name of the ability pack. |
+| `host_plugin_name`  | no       | string | Display name of the host plugin (the installed plugin's own name is preferred when present). |
+| `ability_pack_slug` | no       | string | The companion plugin's own slug (`folder/file.php` or folder). When given, the client also reports whether the pack itself is already installed/active. |
+| `source_url`        | no       | string | Where to get the pack (GitHub repo, wp.org page, etc.). Rendered as a link. |
+| `description`       | no       | string | One-line description shown in the table. |
+| `version`           | no       | string | Latest published version of the pack. |
+
+Entries missing either required field are **silently ignored**. All values are
+trimmed; non-string values are coerced to empty strings.
+
+## Matching behavior
+
+For each entry whose `host_plugin_slug` resolves to an **installed** plugin
+(via `get_plugins()`), the UI shows a row with the installed plugin name, the
+ability pack (linked to `source_url`), and a status:
+
+- **Available to add** — host plugin installed, pack not installed.
+- **Installed, inactive** — `ability_pack_slug` is installed but not active.
+- **Installed & active** — `ability_pack_slug` is installed and active.
+
+Slug matching is robust to folder-vs-full-path differences and to single-file
+plugins (e.g. `hello.php` ⇄ `hello`).
+
+## Companion-plugin targeting convention
+
+This directory keys each pack by the **host WP plugin** it extends
+(`host_plugin_slug`). That should line up with whatever convention the
+ability-API side uses to declare which host plugin a companion targets — when
+reconciling, treat `host_plugin_slug` as the join key.
+
+See [`directory.json`](directory.json) for a working sample.

--- a/plugin/docs/directory.json
+++ b/plugin/docs/directory.json
@@ -2,8 +2,8 @@
   "schema_version": 1,
   "entries": [
     {
-      "host_plugin_slug": "woocommerce/woocommerce.php",
-      "host_plugin_name": "WooCommerce",
+      "target_plugin": "woocommerce/woocommerce.php",
+      "target_plugin_name": "WooCommerce",
       "ability_pack_slug": "agent-connector-woocommerce/agent-connector-woocommerce.php",
       "ability_pack_name": "Agent Connector for WooCommerce",
       "source_url": "https://github.com/soflyy/agent-connector-woocommerce",
@@ -11,8 +11,8 @@
       "version": "1.0.0"
     },
     {
-      "host_plugin_slug": "contact-form-7",
-      "host_plugin_name": "Contact Form 7",
+      "target_plugin": "contact-form-7",
+      "target_plugin_name": "Contact Form 7",
       "ability_pack_slug": "agent-connector-cf7",
       "ability_pack_name": "Agent Connector for Contact Form 7",
       "source_url": "https://github.com/soflyy/agent-connector-cf7",
@@ -20,8 +20,8 @@
       "version": "0.3.1"
     },
     {
-      "host_plugin_slug": "wordpress-seo/wp-seo.php",
-      "host_plugin_name": "Yoast SEO",
+      "target_plugin": "wordpress-seo/wp-seo.php",
+      "target_plugin_name": "Yoast SEO",
       "ability_pack_slug": "agent-connector-yoast/agent-connector-yoast.php",
       "ability_pack_name": "Agent Connector for Yoast SEO",
       "source_url": "https://github.com/soflyy/agent-connector-yoast",

--- a/plugin/docs/directory.json
+++ b/plugin/docs/directory.json
@@ -1,0 +1,32 @@
+{
+  "schema_version": 1,
+  "entries": [
+    {
+      "host_plugin_slug": "woocommerce/woocommerce.php",
+      "host_plugin_name": "WooCommerce",
+      "ability_pack_slug": "agent-connector-woocommerce/agent-connector-woocommerce.php",
+      "ability_pack_name": "Agent Connector for WooCommerce",
+      "source_url": "https://github.com/soflyy/agent-connector-woocommerce",
+      "description": "Exposes order, product, and customer abilities so agents can manage your store over MCP.",
+      "version": "1.0.0"
+    },
+    {
+      "host_plugin_slug": "contact-form-7",
+      "host_plugin_name": "Contact Form 7",
+      "ability_pack_slug": "agent-connector-cf7",
+      "ability_pack_name": "Agent Connector for Contact Form 7",
+      "source_url": "https://github.com/soflyy/agent-connector-cf7",
+      "description": "Lets agents read submissions and edit form definitions.",
+      "version": "0.3.1"
+    },
+    {
+      "host_plugin_slug": "wordpress-seo/wp-seo.php",
+      "host_plugin_name": "Yoast SEO",
+      "ability_pack_slug": "agent-connector-yoast/agent-connector-yoast.php",
+      "ability_pack_name": "Agent Connector for Yoast SEO",
+      "source_url": "https://github.com/soflyy/agent-connector-yoast",
+      "description": "Abilities for auditing and updating per-post SEO metadata.",
+      "version": "0.9.0"
+    }
+  ]
+}

--- a/plugin/docs/registering-abilities.md
+++ b/plugin/docs/registering-abilities.md
@@ -1,0 +1,307 @@
+# Registering abilities with Agent Connector for WP
+
+This guide is for **third-party plugin authors** (and code generators) who want to
+add a WordPress *ability* that is exposed over the Agent Connector for WP MCP
+server and automatically protected by Agent Connector's security.
+
+> **You write no auth.** When you register through the API below, Agent Connector
+> for WP injects, for every ability:
+>
+> - the **permission check** — administrator **and** super-admin only;
+> - the **domain lock** — calls are blocked if the site's locked domain no longer
+>   matches (prevents a moved/cloned site from acting on a stale identity);
+> - the **audit log** — every invocation is recorded.
+>
+> You do **not** supply `permission_callback`. If you pass one, it is **ignored
+> and overridden**. Just describe the ability and its behavior.
+
+---
+
+## The function
+
+```php
+agent_connector_for_wp_register_ability( string $name, array $args ): void
+```
+
+A short alias is also available and identical:
+
+```php
+acfw_register_ability( string $name, array $args ): void
+```
+
+Both are plain global functions — no `use` statement, no class references. They
+are a thin, stable wrapper over core `wp_register_ability()`.
+
+Call them on the **`wp_abilities_api_init`** action (the same place you would
+call `wp_register_ability()`). Always guard with `function_exists()` so your
+plugin degrades gracefully when Agent Connector for WP is inactive:
+
+```php
+add_action( 'wp_abilities_api_init', function () {
+    if ( ! function_exists( 'agent_connector_for_wp_register_ability' ) ) {
+        return; // Agent Connector for WP not active — register nothing.
+    }
+    agent_connector_for_wp_register_ability( 'my-plugin/do-thing', array( /* ... */ ) );
+} );
+```
+
+### `$name`
+
+Your ability's name, in the form `vendor/ability`. Use **your own** vendor
+namespace (your plugin slug), e.g. `my-plugin/do-thing`. Lowercase letters,
+digits, and dashes only, with exactly one `/`. Do **not** use the
+`agent-connector-for-wp/` namespace — that is reserved for the host plugin's
+built-in abilities.
+
+### `$args`
+
+| Key                  | Type       | Required | Notes |
+| -------------------- | ---------- | :------: | ----- |
+| `label`              | string     | yes | Short human-readable name. |
+| `description`        | string     | yes | What the ability does. The agent reads this to decide when to call it — be precise. |
+| `category`           | string     | yes | A **registered** ability-category slug (see below). |
+| `input_schema`       | array      | recommended | JSON Schema for the input object. |
+| `output_schema`      | array      | recommended | JSON Schema for the result object. |
+| `execute_callback`   | callable   | yes | `fn(array $input): array|WP_Error` — your logic. |
+| `summarize`          | callable   | optional | `fn(array $input): array` — a **redacted** summary written to the audit log. See [Audit redaction](#audit-redaction). |
+| `annotations`        | array      | optional | Behavior hints: `readonly`, `destructive`, `idempotent` (booleans). Shorthand for `meta.annotations`. |
+| `meta`               | array      | optional | Extra ability meta. Any `mcp.public` / `show_in_rest` you set is overridden — see below. |
+| `permission_callback`| callable   | — | **Ignored.** Auth is owned by Agent Connector for WP. |
+
+Agent Connector forces `meta.mcp.public = true` and `meta.show_in_rest = true`
+so the MCP adapter surfaces the ability. You never set those yourself.
+
+---
+
+## Registering a category
+
+Every ability belongs to a category, which must be registered **before** the
+ability, on the `wp_abilities_api_categories_init` action:
+
+```php
+add_action( 'wp_abilities_api_categories_init', function () {
+    if ( ! function_exists( 'wp_register_ability_category' ) ) {
+        return;
+    }
+    wp_register_ability_category( 'my-plugin', array(
+        'label'       => 'My Plugin',
+        'description' => 'Abilities contributed by My Plugin.',
+    ) );
+} );
+```
+
+You may reuse an existing category slug (including `agent-connector-for-wp`) or
+define your own. Defining your own is recommended so your abilities group
+cleanly.
+
+---
+
+## Input / output JSON-schema conventions
+
+- The **input schema** should be a JSON Schema `object`:
+  - `type: 'object'`,
+  - a `properties` map (each property typed, with a `description`),
+  - a `required` array for mandatory fields,
+  - `additionalProperties: false` to reject unexpected keys.
+- The **output schema** should likewise be an `object` describing the array your
+  `execute_callback` returns. The Abilities API validates your return value
+  against it, so keep it in sync with what you actually return.
+- Your `execute_callback` receives the validated `$input` as an associative
+  array and must return either an **associative array** matching `output_schema`,
+  or a `WP_Error` on failure.
+
+```php
+'input_schema' => array(
+    'type'                 => 'object',
+    'properties'           => array(
+        'path' => array( 'type' => 'string', 'description' => 'File to read.' ),
+    ),
+    'required'             => array( 'path' ),
+    'additionalProperties' => false,
+),
+'output_schema' => array(
+    'type'       => 'object',
+    'properties' => array(
+        'contents' => array( 'type' => 'string' ),
+        'size'     => array( 'type' => 'integer' ),
+    ),
+),
+```
+
+---
+
+## Audit redaction
+
+Every invocation is written to the Agent Connector audit log. By default the
+log records the ability name, status, duration, user, and IP — but **none of
+your input**, so nothing leaks by accident.
+
+If you want a (safe) summary of the input in the log, provide a `summarize`
+callback. It receives the same `$input` and returns a small associative array.
+**Redact secrets and truncate large values** — whatever you return is written
+verbatim:
+
+```php
+'summarize' => function ( array $input ): array {
+    return array(
+        // Safe to log:
+        'path'    => isset( $input['path'] ) ? (string) $input['path'] : '',
+        // Truncate big blobs:
+        'command' => isset( $input['command'] ) ? mb_substr( (string) $input['command'], 0, 500 ) : '',
+        // Do NOT include tokens, passwords, file contents, etc.
+    );
+},
+```
+
+---
+
+## Complete minimal companion plugin
+
+A full, copy-pasteable single-file plugin that registers one ability. The same
+file ships as a reference under
+[`examples/acfw-ability-pack-hello/`](../examples/acfw-ability-pack-hello/acfw-ability-pack-hello.php).
+
+```php
+<?php
+/**
+ * Plugin Name:       My Ability Pack
+ * Description:        Adds the my-plugin/do-thing ability to Agent Connector for WP.
+ * Version:           1.0.0
+ * Requires Plugins:  agent-connector-for-wp
+ * Requires PHP:      8.1
+ * License:           GPL-2.0-or-later
+ *
+ * Agent Connector: Ability Pack
+ * Agent Connector Host: agent-connector-for-wp
+ */
+
+declare( strict_types=1 );
+
+defined( 'ABSPATH' ) || exit;
+
+add_action( 'wp_abilities_api_categories_init', function () {
+    if ( ! function_exists( 'wp_register_ability_category' ) ) {
+        return;
+    }
+    wp_register_ability_category( 'my-plugin', array(
+        'label'       => 'My Plugin',
+        'description' => 'Abilities contributed by My Plugin.',
+    ) );
+} );
+
+add_action( 'wp_abilities_api_init', function () {
+    if ( ! function_exists( 'agent_connector_for_wp_register_ability' ) ) {
+        return; // Host plugin inactive — register nothing.
+    }
+
+    agent_connector_for_wp_register_ability( 'my-plugin/do-thing', array(
+        'label'         => 'Do Thing',
+        'description'   => 'Does the thing and returns a result.',
+        'category'      => 'my-plugin',
+        'input_schema'  => array(
+            'type'                 => 'object',
+            'properties'           => array(
+                'name' => array( 'type' => 'string', 'description' => 'What to act on.' ),
+            ),
+            'required'             => array( 'name' ),
+            'additionalProperties' => false,
+        ),
+        'output_schema' => array(
+            'type'       => 'object',
+            'properties' => array( 'message' => array( 'type' => 'string' ) ),
+        ),
+        'annotations'   => array( 'readonly' => true, 'idempotent' => true ),
+
+        // Your logic. Return an array (matching output_schema) or a WP_Error.
+        'execute_callback' => function ( array $input ) {
+            $name = isset( $input['name'] ) ? (string) $input['name'] : '';
+            if ( '' === $name ) {
+                return new WP_Error( 'my_plugin_bad_input', 'name is required', array( 'status' => 400 ) );
+            }
+            return array( 'message' => "Did the thing for {$name}." );
+        },
+
+        // Optional: redacted audit-log summary.
+        'summarize' => function ( array $input ): array {
+            return array( 'name' => isset( $input['name'] ) ? (string) $input['name'] : '' );
+        },
+    ) );
+} );
+```
+
+That's the whole plugin. **No** permission callback, **no** domain-lock check,
+**no** logging — Agent Connector for WP provides all three.
+
+---
+
+## Companion "ability pack" plugin convention
+
+A companion plugin that exists to add abilities to a specific host MCP plugin is
+an **ability pack**. A remote directory feature discovers ability packs by their
+plugin header, so follow this convention exactly:
+
+1. **Slug / folder.** Name the plugin `<host-slug>-ability-pack-<topic>`, e.g.
+   `agent-connector-for-wp-ability-pack-woocommerce`. The folder, main file, and
+   `Plugin Name` should agree.
+
+2. **Declare the host plugin.** Two header lines:
+
+   - `Requires Plugins: agent-connector-for-wp` — core WordPress dependency
+     header, so WordPress won't activate your pack without the host.
+   - `Agent Connector Host: agent-connector-for-wp` — the machine-readable marker
+     the directory uses to know **which** host MCP plugin this pack targets. The
+     value is the host plugin's slug.
+
+   And one marker line that identifies the file as an ability pack at all:
+
+   - `Agent Connector: Ability Pack`
+
+   ```php
+   /**
+    * Plugin Name:       Agent Connector for WP Ability Pack: WooCommerce
+    * Requires Plugins:  agent-connector-for-wp
+    *
+    * Agent Connector: Ability Pack
+    * Agent Connector Host: agent-connector-for-wp
+    */
+   ```
+
+3. **Namespace your abilities** under your pack's own vendor prefix
+   (`woo/...`, `my-plugin/...`) — never `agent-connector-for-wp/...`.
+
+4. **Register on the standard hooks** (`wp_abilities_api_categories_init` then
+   `wp_abilities_api_init`) and **guard with `function_exists()`** so the pack is
+   inert when the host is absent.
+
+5. **Don't bundle** wordpress/mcp-adapter or the Abilities API — the host plugin
+   provides them.
+
+Following this convention means: your pack activates only alongside the host,
+the directory can list it under the right host, and every ability you register is
+automatically governed by the host's auth, domain lock, and audit log.
+
+---
+
+## How the protection is applied (for the curious)
+
+You don't need this to use the API, but for transparency: Agent Connector hooks
+the core `wp_register_ability_args` filter and, for **every** ability that will
+be MCP-exposed (`meta.mcp.public === true`) — whether registered through this API
+or via raw `wp_register_ability()` — it overrides `permission_callback` with its
+admin/super-admin check and wraps `execute_callback` with its domain-lock +
+audit chokepoint. This is a security backstop: no ability reachable through the
+Agent Connector MCP server can run under someone else's (or no) authentication.
+
+If an integrator deliberately needs to opt a specific ability out of this
+governance (taking over its auth themselves), they can filter it:
+
+```php
+add_filter( 'agent_connector_for_wp_govern_ability', function ( $govern, $name, $args ) {
+    if ( 'some-plugin/special' === $name ) {
+        return false; // We accept full responsibility for this ability's auth.
+    }
+    return $govern;
+}, 10, 3 );
+```
+
+The default is to govern every MCP-exposed ability.

--- a/plugin/docs/registering-abilities.md
+++ b/plugin/docs/registering-abilities.md
@@ -172,7 +172,6 @@ file ships as a reference under
  * License:           GPL-2.0-or-later
  *
  * Agent Connector: Ability Pack
- * Agent Connector Host: agent-connector-for-wp
  */
 
 declare( strict_types=1 );
@@ -240,21 +239,26 @@ A companion plugin that exists to add abilities to a specific host MCP plugin is
 an **ability pack**. A remote directory feature discovers ability packs by their
 plugin header, so follow this convention exactly:
 
-1. **Slug / folder.** Name the plugin `<host-slug>-ability-pack-<topic>`, e.g.
+1. **Slug / folder.** Name the plugin
+   `agent-connector-for-wp-ability-pack-<target>`, e.g.
    `agent-connector-for-wp-ability-pack-woocommerce`. The folder, main file, and
    `Plugin Name` should agree.
 
-2. **Declare the host plugin.** Two header lines:
+2. **Declare dependency, identity, and target.** Three header lines:
 
    - `Requires Plugins: agent-connector-for-wp` — core WordPress dependency
-     header, so WordPress won't activate your pack without the host.
-   - `Agent Connector Host: agent-connector-for-wp` — the machine-readable marker
-     the directory uses to know **which** host MCP plugin this pack targets. The
-     value is the host plugin's slug.
-
-   And one marker line that identifies the file as an ability pack at all:
-
-   - `Agent Connector: Ability Pack`
+     header, so WordPress won't activate your pack without Agent Connector. (This
+     is also how a pack declares it plugs into Agent Connector — there is no
+     separate "host" header.)
+   - `Agent Connector: Ability Pack` — the marker that identifies the file as an
+     ability pack at all.
+   - `Agent Connector Target: woocommerce/woocommerce.php` — **the WP plugin this
+     pack extends.** This is the canonical join key: the published ability-pack
+     directory keys each entry on the same value (its `target_plugin` field), so
+     the two must match for the site to surface your pack against an installed
+     plugin. Use the plugin file (`woocommerce/woocommerce.php`) or a bare folder
+     slug (`woocommerce`) — both are matched. Omit it only for a pack that
+     doesn't extend a specific plugin (it just won't appear in the directory).
 
    ```php
    /**
@@ -262,7 +266,7 @@ plugin header, so follow this convention exactly:
     * Requires Plugins:  agent-connector-for-wp
     *
     * Agent Connector: Ability Pack
-    * Agent Connector Host: agent-connector-for-wp
+    * Agent Connector Target: woocommerce/woocommerce.php
     */
    ```
 
@@ -276,9 +280,10 @@ plugin header, so follow this convention exactly:
 5. **Don't bundle** wordpress/mcp-adapter or the Abilities API — the host plugin
    provides them.
 
-Following this convention means: your pack activates only alongside the host,
-the directory can list it under the right host, and every ability you register is
-automatically governed by the host's auth, domain lock, and audit log.
+Following this convention means: your pack activates only alongside Agent
+Connector, the directory can list it under the right target plugin, and every
+ability you register is automatically governed by Agent Connector's auth, domain
+lock, and audit log.
 
 ---
 

--- a/plugin/examples/acfw-ability-pack-hello/acfw-ability-pack-hello.php
+++ b/plugin/examples/acfw-ability-pack-hello/acfw-ability-pack-hello.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * Plugin Name:       ACFW Ability Pack: Hello
+ * Description:        Example companion "ability pack" for Agent Connector for WP. Registers one ability (hello/greet) over the public registration API. Reference only — not wired into production.
+ * Version:           1.0.0
+ * Requires Plugins:  agent-connector-for-wp
+ * Requires PHP:      8.1
+ * Author:            Soflyy
+ * License:           GPL-2.0-or-later
+ *
+ * Agent Connector: Ability Pack
+ * Agent Connector Host: agent-connector-for-wp
+ *
+ * @package AcfwAbilityPackHello
+ *
+ * This file is a copy-pasteable template for a companion plugin. It writes NO
+ * permission / auth / domain-lock / audit code: Agent Connector for WP injects
+ * all of that (admin/super-admin gate, domain lock, audit log) for every ability
+ * registered through agent_connector_for_wp_register_ability().
+ *
+ * See plugin/docs/registering-abilities.md for the full guide.
+ */
+
+declare( strict_types=1 );
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Register an ability category for this pack.
+ *
+ * Categories must be registered on wp_abilities_api_categories_init, before the
+ * abilities that reference them.
+ */
+add_action(
+	'wp_abilities_api_categories_init',
+	static function (): void {
+		if ( ! function_exists( 'wp_register_ability_category' ) ) {
+			return;
+		}
+		wp_register_ability_category(
+			'hello',
+			array(
+				'label'       => 'Hello Pack',
+				'description' => 'Example abilities contributed by the Hello ability pack.',
+			)
+		);
+	}
+);
+
+/**
+ * Register the ability itself.
+ *
+ * Guarded by function_exists() so the pack degrades gracefully (registers
+ * nothing) when Agent Connector for WP is inactive or the public API is absent.
+ */
+add_action(
+	'wp_abilities_api_init',
+	static function (): void {
+		if ( ! function_exists( 'agent_connector_for_wp_register_ability' ) ) {
+			return;
+		}
+
+		agent_connector_for_wp_register_ability(
+			'hello/greet',
+			array(
+				'label'         => 'Greet',
+				'description'   => 'Return a friendly greeting for the given name.',
+				'category'      => 'hello',
+				'input_schema'  => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'name' => array(
+							'type'        => 'string',
+							'description' => 'Who to greet.',
+						),
+					),
+					'required'             => array( 'name' ),
+					'additionalProperties' => false,
+				),
+				'output_schema' => array(
+					'type'       => 'object',
+					'properties' => array(
+						'message' => array( 'type' => 'string' ),
+					),
+				),
+				'annotations'   => array(
+					'readonly'    => true,
+					'idempotent'  => true,
+					'destructive' => false,
+				),
+				// fn(array $input): array|WP_Error
+				'execute_callback' => static function ( array $input ): array {
+					$name = isset( $input['name'] ) ? (string) $input['name'] : 'world';
+					return array( 'message' => sprintf( 'Hello, %s!', $name ) );
+				},
+				// Optional: redact the audit-log summary. Here the name is safe,
+				// so we log it verbatim; redact secrets/large blobs in real packs.
+				'summarize'        => static function ( array $input ): array {
+					return array( 'name' => isset( $input['name'] ) ? (string) $input['name'] : '' );
+				},
+			)
+		);
+	}
+);

--- a/plugin/examples/acfw-ability-pack-hello/acfw-ability-pack-hello.php
+++ b/plugin/examples/acfw-ability-pack-hello/acfw-ability-pack-hello.php
@@ -9,7 +9,11 @@
  * License:           GPL-2.0-or-later
  *
  * Agent Connector: Ability Pack
- * Agent Connector Host: agent-connector-for-wp
+ *
+ * A real pack that extends a specific WP plugin also declares, e.g.:
+ *   Agent Connector Target: woocommerce/woocommerce.php
+ * This demo extends nothing in particular, so it omits the Target header and
+ * does not appear in the ability-pack directory.
  *
  * @package AcfwAbilityPackHello
  *

--- a/plugin/src/Admin/ConnectionPage.php
+++ b/plugin/src/Admin/ConnectionPage.php
@@ -430,6 +430,8 @@ final class ConnectionPage {
 			'saved'        => array( 'success', __( 'Settings saved.', 'agent-connector-for-wp' ) ),
 			'prod_blocked' => array( 'warning', __( 'Saved, but Agent Connector is inactive: this is a production environment. Tick the production override to activate it.', 'agent-connector-for-wp' ) ),
 			'reconnected'  => array( 'success', __( 'Reconnected — abilities are allowed on this domain again.', 'agent-connector-for-wp' ) ),
+			'safe_mode_cleared'     => array( 'success', __( 'Sandbox safe mode cleared. Sandbox files will load again on the next request.', 'agent-connector-for-wp' ) ),
+			'safe_mode_clear_failed' => array( 'error', __( 'Could not clear sandbox safe mode — delete the ".crashed" marker file manually.', 'agent-connector-for-wp' ) ),
 		);
 
 		if ( ! isset( $messages[ $notice ] ) ) {

--- a/plugin/src/Admin/DirectoryPage.php
+++ b/plugin/src/Admin/DirectoryPage.php
@@ -158,9 +158,9 @@ final class DirectoryPage {
 		?>
 		<tr>
 			<td>
-				<strong><?php echo esc_html( (string) $match['host_plugin_name'] ); ?></strong><br />
-				<code style="font-size:11px;"><?php echo esc_html( (string) $match['host_plugin_file'] ); ?></code>
-				<?php if ( ! $match['host_active'] ) : ?>
+				<strong><?php echo esc_html( (string) $match['target_plugin_name'] ); ?></strong><br />
+				<code style="font-size:11px;"><?php echo esc_html( (string) $match['target_plugin_file'] ); ?></code>
+				<?php if ( ! $match['target_active'] ) : ?>
 					<br /><span class="description"><?php esc_html_e( '(installed, not active)', 'agent-connector-for-wp' ); ?></span>
 				<?php endif; ?>
 			</td>

--- a/plugin/src/Admin/DirectoryPage.php
+++ b/plugin/src/Admin/DirectoryPage.php
@@ -1,0 +1,218 @@
+<?php
+/**
+ * The "Ability Packs" admin screen: shows which installed plugins have an
+ * available Agent Connector ability pack in the remote directory.
+ *
+ * @package AgentConnectorForWp
+ */
+
+declare( strict_types=1 );
+
+namespace AgentConnectorForWp\Admin;
+
+use AgentConnectorForWp\Services\PluginDirectory;
+use AgentConnectorForWp\Support\Config;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Read-only directory browser.
+ *
+ * Submenu under the top-level "Agent Connector for WP" menu. It fetches a remote
+ * directory of companion "ability pack" plugins (cached for 12h), matches it
+ * against the plugins installed here, and lists the hits. Purely informational —
+ * it never installs anything. A manual "Refresh now" button (admin-post + nonce)
+ * busts the cache. Visibility is gated behind the same capability as the rest of
+ * the plugin's admin area.
+ */
+final class DirectoryPage {
+
+	public const MENU_SLUG = 'agent-connector-for-wp-ability-packs';
+
+	private const REFRESH_ACTION = 'agent_connector_for_wp_refresh_directory';
+
+	public function register(): void {
+		add_action( 'admin_menu', array( $this, 'register_menu' ) );
+		add_action( 'admin_post_' . self::REFRESH_ACTION, array( $this, 'handle_refresh' ) );
+	}
+
+	/**
+	 * Add the "Ability Packs" submenu beneath the plugin's top-level menu.
+	 */
+	public function register_menu(): void {
+		add_submenu_page(
+			ConnectionPage::MENU_SLUG,
+			__( 'Agent Connector — Ability Packs', 'agent-connector-for-wp' ),
+			__( 'Ability Packs', 'agent-connector-for-wp' ),
+			Config::CAP,
+			self::MENU_SLUG,
+			array( $this, 'render_page' )
+		);
+	}
+
+	/**
+	 * Render the Ability Packs screen.
+	 */
+	public function render_page(): void {
+		if ( ! current_user_can( Config::CAP ) ) {
+			return;
+		}
+
+		$result   = PluginDirectory::matches();
+		$matches  = $result['matches'];
+		$notice   = isset( $_GET['acfw_notice'] ) ? sanitize_key( wp_unslash( $_GET['acfw_notice'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		?>
+		<div class="wrap">
+			<h1><?php esc_html_e( 'Agent Connector for WP — Ability Packs', 'agent-connector-for-wp' ); ?></h1>
+
+			<?php if ( 'refreshed' === $notice ) : ?>
+				<div class="notice notice-success is-dismissible"><p><?php esc_html_e( 'Directory refreshed.', 'agent-connector-for-wp' ); ?></p></div>
+			<?php endif; ?>
+
+			<p style="max-width:50em;">
+				<?php esc_html_e( 'Some plugins on this site can be extended with a companion "ability pack" that registers AI abilities through Agent Connector. This page checks the published directory of ability packs against your installed plugins and lists the matches. It is informational only — nothing is installed automatically.', 'agent-connector-for-wp' ); ?>
+			</p>
+
+			<?php $this->render_toolbar( $result ); ?>
+
+			<?php if ( '' !== $result['error'] && empty( $matches ) ) : ?>
+				<div class="notice notice-warning inline" style="max-width:50em;">
+					<p><?php echo esc_html( $result['error'] ); ?></p>
+				</div>
+			<?php elseif ( $result['stale'] ) : ?>
+				<div class="notice notice-warning inline" style="max-width:50em;">
+					<p><?php echo esc_html( $result['error'] ); ?></p>
+				</div>
+			<?php endif; ?>
+
+			<?php $this->render_matches_table( $matches ); ?>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Source line + manual refresh button.
+	 *
+	 * @param array<string,mixed> $result PluginDirectory::matches() result.
+	 */
+	private function render_toolbar( array $result ): void {
+		?>
+		<p class="description" style="max-width:50em;">
+			<?php
+			printf(
+				/* translators: %s: directory URL. */
+				esc_html__( 'Directory source: %s', 'agent-connector-for-wp' ),
+				'<code>' . esc_html( (string) $result['url'] ) . '</code>'
+			);
+			?>
+		</p>
+		<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" style="margin:.6em 0 1.2em;">
+			<input type="hidden" name="action" value="<?php echo esc_attr( self::REFRESH_ACTION ); ?>" />
+			<?php wp_nonce_field( self::REFRESH_ACTION ); ?>
+			<?php submit_button( __( 'Refresh now', 'agent-connector-for-wp' ), 'secondary', 'submit', false ); ?>
+		</form>
+		<?php
+	}
+
+	/**
+	 * Render the matches table (or an empty-state message).
+	 *
+	 * @param array<int,array<string,mixed>> $matches PluginDirectory matches.
+	 */
+	private function render_matches_table( array $matches ): void {
+		if ( empty( $matches ) ) {
+			?>
+			<p><em><?php esc_html_e( 'None of your installed plugins have an ability pack in the directory yet.', 'agent-connector-for-wp' ); ?></em></p>
+			<?php
+			return;
+		}
+		?>
+		<table class="widefat striped" style="max-width:64em;margin-top:1em;">
+			<thead>
+				<tr>
+					<th scope="col"><?php esc_html_e( 'Installed plugin', 'agent-connector-for-wp' ); ?></th>
+					<th scope="col"><?php esc_html_e( 'Ability pack', 'agent-connector-for-wp' ); ?></th>
+					<th scope="col"><?php esc_html_e( 'Status', 'agent-connector-for-wp' ); ?></th>
+				</tr>
+			</thead>
+			<tbody>
+				<?php foreach ( $matches as $match ) : ?>
+					<?php $this->render_match_row( $match ); ?>
+				<?php endforeach; ?>
+			</tbody>
+		</table>
+		<?php
+	}
+
+	/**
+	 * Render one match row.
+	 *
+	 * @param array<string,mixed> $match A single PluginDirectory match.
+	 */
+	private function render_match_row( array $match ): void {
+		$entry      = (array) $match['entry'];
+		$pack_name  = (string) ( $entry['ability_pack_name'] ?? '' );
+		$desc       = (string) ( $entry['description'] ?? '' );
+		$source_url = (string) ( $entry['source_url'] ?? '' );
+		$version    = (string) ( $entry['version'] ?? '' );
+		?>
+		<tr>
+			<td>
+				<strong><?php echo esc_html( (string) $match['host_plugin_name'] ); ?></strong><br />
+				<code style="font-size:11px;"><?php echo esc_html( (string) $match['host_plugin_file'] ); ?></code>
+				<?php if ( ! $match['host_active'] ) : ?>
+					<br /><span class="description"><?php esc_html_e( '(installed, not active)', 'agent-connector-for-wp' ); ?></span>
+				<?php endif; ?>
+			</td>
+			<td>
+				<strong>
+					<?php if ( '' !== $source_url ) : ?>
+						<a href="<?php echo esc_url( $source_url ); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html( $pack_name ); ?></a>
+					<?php else : ?>
+						<?php echo esc_html( $pack_name ); ?>
+					<?php endif; ?>
+				</strong>
+				<?php if ( '' !== $version ) : ?>
+					<span class="description">v<?php echo esc_html( $version ); ?></span>
+				<?php endif; ?>
+				<?php if ( '' !== $desc ) : ?>
+					<p class="description" style="margin:.3em 0 0;max-width:40em;"><?php echo esc_html( $desc ); ?></p>
+				<?php endif; ?>
+			</td>
+			<td>
+				<?php if ( $match['pack_active'] ) : ?>
+					<span style="color:#1a7f37;font-weight:600;"><?php esc_html_e( 'Installed &amp; active', 'agent-connector-for-wp' ); ?></span>
+				<?php elseif ( $match['pack_installed'] ) : ?>
+					<span style="color:#996800;font-weight:600;"><?php esc_html_e( 'Installed, inactive', 'agent-connector-for-wp' ); ?></span>
+				<?php else : ?>
+					<span style="color:#2271b1;font-weight:600;"><?php esc_html_e( 'Available to add', 'agent-connector-for-wp' ); ?></span>
+				<?php endif; ?>
+			</td>
+		</tr>
+		<?php
+	}
+
+	/**
+	 * admin-post: clear the cache and refetch, then redirect back.
+	 */
+	public function handle_refresh(): void {
+		if ( ! current_user_can( Config::CAP ) ) {
+			wp_die( esc_html__( 'You do not have permission to do this.', 'agent-connector-for-wp' ), '', array( 'response' => 403 ) );
+		}
+		check_admin_referer( self::REFRESH_ACTION );
+
+		PluginDirectory::clear_cache();
+		PluginDirectory::get( true );
+
+		wp_safe_redirect(
+			add_query_arg(
+				array(
+					'page'        => self::MENU_SLUG,
+					'acfw_notice' => 'refreshed',
+				),
+				admin_url( 'admin.php' )
+			)
+		);
+		exit;
+	}
+}

--- a/plugin/src/Services/AuditLogger.php
+++ b/plugin/src/Services/AuditLogger.php
@@ -56,36 +56,57 @@ final class AuditLogger {
 	/**
 	 * Wrap an ability handler so every invocation is timed and audit-logged.
 	 *
+	 * Returns a {@see WrappedHandler} marker (an invokable, so still `callable`)
+	 * rather than a plain closure. The marker lets the governance layer detect an
+	 * already-wrapped execute callback and avoid wrapping it a second time, which
+	 * would double-log and run the domain-lock check twice. Built-in abilities and
+	 * third-party abilities therefore share one wrapping path.
+	 *
 	 * @param string        $ability    Ability name.
 	 * @param callable      $handler    fn(array $input): mixed|WP_Error
 	 * @param ?callable     $summarizer fn(array $input): array — a redacted summary for the log.
-	 * @return callable The wrapped execute_callback.
+	 * @return WrappedHandler The wrapped execute_callback.
 	 */
-	public static function wrap( string $ability, callable $handler, ?callable $summarizer = null ): callable {
-		return static function ( $input = array() ) use ( $ability, $handler, $summarizer ) {
-			$input = is_array( $input ) ? $input : array();
-			$start = microtime( true );
+	public static function wrap( string $ability, callable $handler, ?callable $summarizer = null ): WrappedHandler {
+		return new WrappedHandler( $ability, $handler, $summarizer );
+	}
 
-			// Domain lock: this is the single chokepoint every ability runs
-			// through, so enforcement lives here rather than in each handler. On
-			// a mismatch we never invoke the handler — we return an
-			// agent-actionable error and still record the blocked attempt.
-			$lock_reason = Config::lock_mismatch_reason();
-			if ( null !== $lock_reason ) {
-				$summary = $summarizer ? (array) $summarizer( $input ) : array();
-				self::log( $ability, $summary, 'error', 0 );
-				return new \WP_Error(
-					'agent_connector_domain_locked',
-					$lock_reason,
-					array( 'status' => 403 )
-				);
-			}
+	/**
+	 * The single chokepoint every wrapped ability runs through: domain-lock
+	 * enforcement, then the handler, then audit logging.
+	 *
+	 * Called by {@see WrappedHandler::__invoke()}. Kept here (rather than inside
+	 * the wrapper) so the enforcement/logging logic lives in one place.
+	 *
+	 * @param string        $ability    Ability name.
+	 * @param callable      $handler    fn(array $input): mixed|WP_Error.
+	 * @param ?callable     $summarizer fn(array $input): array — a redacted summary for the log.
+	 * @param mixed         $input      Raw ability input.
+	 * @return mixed|\WP_Error
+	 */
+	public static function run( string $ability, callable $handler, ?callable $summarizer, $input = array() ) {
+		$input = is_array( $input ) ? $input : array();
+		$start = microtime( true );
 
-			$result  = $handler( $input );
-			$status  = is_wp_error( $result ) ? 'error' : 'ok';
+		// Domain lock: this is the single chokepoint every ability runs
+		// through, so enforcement lives here rather than in each handler. On
+		// a mismatch we never invoke the handler — we return an
+		// agent-actionable error and still record the blocked attempt.
+		$lock_reason = Config::lock_mismatch_reason();
+		if ( null !== $lock_reason ) {
 			$summary = $summarizer ? (array) $summarizer( $input ) : array();
-			self::log( $ability, $summary, $status, (int) round( ( microtime( true ) - $start ) * 1000 ) );
-			return $result;
-		};
+			self::log( $ability, $summary, 'error', 0 );
+			return new \WP_Error(
+				'agent_connector_domain_locked',
+				$lock_reason,
+				array( 'status' => 403 )
+			);
+		}
+
+		$result  = $handler( $input );
+		$status  = is_wp_error( $result ) ? 'error' : 'ok';
+		$summary = $summarizer ? (array) $summarizer( $input ) : array();
+		self::log( $ability, $summary, $status, (int) round( ( microtime( true ) - $start ) * 1000 ) );
+		return $result;
 	}
 }

--- a/plugin/src/Services/FileManager.php
+++ b/plugin/src/Services/FileManager.php
@@ -11,6 +11,7 @@ namespace AgentConnectorForWp\Services;
 
 use AgentConnectorForWp\Support\Config;
 use AgentConnectorForWp\Support\Helpers;
+use AgentConnectorForWp\Support\Sandbox;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -67,6 +68,21 @@ final class FileManager {
 		$resolved = Helpers::resolve_path( $path );
 		if ( '' === $resolved ) {
 			return new \WP_Error( 'agent_connector_for_wp_bad_path', 'No path provided.' );
+		}
+
+		// PHP-execution boundary: .php and execution-control files (.htaccess,
+		// .user.ini, php.ini, web.config) may only be written inside the sandbox
+		// directory, so generated code that runs each request has a single,
+		// recoverable home. Non-PHP writes elsewhere stay allowed by design.
+		$sandbox_check = Sandbox::check_php_execution_boundary( $resolved );
+		if ( is_wp_error( $sandbox_check ) ) {
+			return $sandbox_check;
+		}
+
+		// Never write *through* a symlinked final path.
+		$symlink_check = Sandbox::reject_final_symlink( $resolved );
+		if ( is_wp_error( $symlink_check ) ) {
+			return $symlink_check;
 		}
 
 		$existed = is_file( $resolved );

--- a/plugin/src/Services/PluginDirectory.php
+++ b/plugin/src/Services/PluginDirectory.php
@@ -1,0 +1,396 @@
+<?php
+/**
+ * Client for the remote "ability pack" companion-plugin directory.
+ *
+ * @package AgentConnectorForWp
+ */
+
+declare( strict_types=1 );
+
+namespace AgentConnectorForWp\Services;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Fetches a remote JSON directory of companion "ability pack" plugins and matches
+ * its entries against the WP plugins installed on this site.
+ *
+ * The directory is a published list of third-party companion plugins, each of
+ * which targets a specific host WP plugin (e.g. an ability pack "for WooCommerce")
+ * and registers AI abilities through Agent Connector's API. This client tells the
+ * admin which of *their* installed plugins have an ability pack available.
+ *
+ * Network access is best-effort and never fatal: the result is cached in a
+ * transient, failures fall back to the last good copy, and malformed JSON or
+ * entries are ignored defensively. See docs/directory-schema.md for the schema.
+ */
+final class PluginDirectory {
+
+	/**
+	 * Default remote directory URL.
+	 *
+	 * PLACEHOLDER — there is no live endpoint yet. Point this (or the
+	 * `agent_connector_for_wp_directory_url` filter) at the real published
+	 * directory.json before relying on it. A 404 here is handled gracefully:
+	 * the UI shows a clean "directory unavailable" state, never a fatal.
+	 */
+	public const DEFAULT_DIRECTORY_URL = 'https://raw.githubusercontent.com/soflyy/agent-connector-for-wp-directory/main/directory.json';
+
+	/**
+	 * Transient holding the last successfully fetched + normalized directory.
+	 *
+	 * @var array<int,array<string,string>>|false
+	 */
+	public const CACHE_KEY = 'agent_connector_for_wp_directory_cache';
+
+	/**
+	 * Transient lifetime: 12 hours.
+	 */
+	public const CACHE_TTL = 12 * HOUR_IN_SECONDS;
+
+	/**
+	 * Network timeout for the directory fetch, in seconds. Kept short so a slow
+	 * or unreachable endpoint never stalls an admin page render for long.
+	 */
+	private const HTTP_TIMEOUT = 5;
+
+	/**
+	 * The remote directory URL, after the override filter.
+	 */
+	public static function directory_url(): string {
+		/**
+		 * Filters the URL of the remote ability-pack directory.
+		 *
+		 * @param string $url Default directory URL.
+		 */
+		$url = (string) apply_filters( 'agent_connector_for_wp_directory_url', self::DEFAULT_DIRECTORY_URL );
+
+		return $url;
+	}
+
+	/**
+	 * Return the cached directory, or null when nothing has been cached yet.
+	 *
+	 * @return array<int,array<string,string>>|null
+	 */
+	public static function cached(): ?array {
+		$cached = get_transient( self::CACHE_KEY );
+
+		return is_array( $cached ) ? $cached : null;
+	}
+
+	/**
+	 * Fetch the directory, preferring the cache. On a cache miss it hits the
+	 * network; on a network/parse failure it falls back to any stale cached copy.
+	 *
+	 * @param bool $force When true, bypass the cache and refetch from the network.
+	 *
+	 * @return array{
+	 *     entries: array<int,array<string,string>>,
+	 *     stale: bool,
+	 *     error: string,
+	 *     url: string
+	 * }
+	 */
+	public static function get( bool $force = false ): array {
+		$url = self::directory_url();
+
+		if ( ! $force ) {
+			$cached = self::cached();
+			if ( null !== $cached ) {
+				return array(
+					'entries' => $cached,
+					'stale'   => false,
+					'error'   => '',
+					'url'     => $url,
+				);
+			}
+		}
+
+		$fetched = self::fetch( $url );
+
+		if ( null !== $fetched ) {
+			set_transient( self::CACHE_KEY, $fetched, self::CACHE_TTL );
+
+			return array(
+				'entries' => $fetched,
+				'stale'   => false,
+				'error'   => '',
+				'url'     => $url,
+			);
+		}
+
+		// Network/parse failed — fall back to any (possibly stale) cached copy.
+		$cached = self::cached();
+		if ( null !== $cached ) {
+			return array(
+				'entries' => $cached,
+				'stale'   => true,
+				'error'   => __( 'Could not refresh the directory; showing the last cached copy.', 'agent-connector-for-wp' ),
+				'url'     => $url,
+			);
+		}
+
+		return array(
+			'entries' => array(),
+			'stale'   => false,
+			'error'   => __( 'The ability-pack directory is currently unavailable.', 'agent-connector-for-wp' ),
+			'url'     => $url,
+		);
+	}
+
+	/**
+	 * Drop the cached directory so the next read refetches.
+	 */
+	public static function clear_cache(): void {
+		delete_transient( self::CACHE_KEY );
+	}
+
+	/**
+	 * Fetch + decode + normalize the directory from the network.
+	 *
+	 * @param string $url Directory URL.
+	 *
+	 * @return array<int,array<string,string>>|null Normalized entries, or null on any failure.
+	 */
+	private static function fetch( string $url ): ?array {
+		if ( '' === $url || ! function_exists( 'wp_remote_get' ) ) {
+			return null;
+		}
+
+		$response = wp_remote_get(
+			$url,
+			array(
+				'timeout'    => self::HTTP_TIMEOUT,
+				'user-agent' => 'AgentConnectorForWp/' . ( defined( 'AGENT_CONNECTOR_FOR_WP_VERSION' ) ? AGENT_CONNECTOR_FOR_WP_VERSION : 'dev' ),
+				'headers'    => array( 'Accept' => 'application/json' ),
+			)
+		);
+
+		if ( $response instanceof \WP_Error ) {
+			return null;
+		}
+
+		if ( 200 !== (int) wp_remote_retrieve_response_code( $response ) ) {
+			return null;
+		}
+
+		$body = wp_remote_retrieve_body( $response );
+		if ( '' === $body ) {
+			return null;
+		}
+
+		$decoded = json_decode( $body, true );
+		if ( JSON_ERROR_NONE !== json_last_error() ) {
+			return null;
+		}
+
+		return self::normalize( $decoded );
+	}
+
+	/**
+	 * Normalize a decoded directory payload into a clean list of entries.
+	 *
+	 * Accepts either a top-level array of entries, or an object with an
+	 * `entries` key holding that array. Malformed entries (missing the two
+	 * required keys) are silently dropped.
+	 *
+	 * @param mixed $decoded Decoded JSON.
+	 *
+	 * @return array<int,array<string,string>>
+	 */
+	private static function normalize( $decoded ): array {
+		if ( is_array( $decoded ) && isset( $decoded['entries'] ) && is_array( $decoded['entries'] ) ) {
+			$raw = $decoded['entries'];
+		} elseif ( is_array( $decoded ) ) {
+			$raw = $decoded;
+		} else {
+			return array();
+		}
+
+		$entries = array();
+		foreach ( $raw as $item ) {
+			$entry = self::normalize_entry( $item );
+			if ( null !== $entry ) {
+				$entries[] = $entry;
+			}
+		}
+
+		return $entries;
+	}
+
+	/**
+	 * Validate + normalize a single directory entry, or null if it is unusable.
+	 *
+	 * Required: host_plugin_slug, ability_pack_name. Everything else is
+	 * optional and defaulted to an empty string.
+	 *
+	 * @param mixed $item Raw entry.
+	 *
+	 * @return array<string,string>|null
+	 */
+	private static function normalize_entry( $item ): ?array {
+		if ( ! is_array( $item ) ) {
+			return null;
+		}
+
+		$host_slug = isset( $item['host_plugin_slug'] ) && is_string( $item['host_plugin_slug'] )
+			? trim( $item['host_plugin_slug'] )
+			: '';
+		$pack_name = isset( $item['ability_pack_name'] ) && is_string( $item['ability_pack_name'] )
+			? trim( $item['ability_pack_name'] )
+			: '';
+
+		if ( '' === $host_slug || '' === $pack_name ) {
+			return null;
+		}
+
+		$str = static function ( $value ): string {
+			return is_string( $value ) ? trim( $value ) : '';
+		};
+
+		return array(
+			'host_plugin_slug' => $host_slug,
+			'host_plugin_name' => $str( $item['host_plugin_name'] ?? '' ),
+			'ability_pack_slug' => $str( $item['ability_pack_slug'] ?? '' ),
+			'ability_pack_name' => $pack_name,
+			'source_url'        => $str( $item['source_url'] ?? '' ),
+			'description'       => $str( $item['description'] ?? '' ),
+			'version'           => $str( $item['version'] ?? '' ),
+		);
+	}
+
+	/**
+	 * Match directory entries against the plugins installed on this site.
+	 *
+	 * @param array<int,array<string,string>> $entries Normalized directory entries.
+	 *
+	 * @return array<int,array<string,mixed>> One row per match, each with the
+	 *     directory entry plus host_installed / host_active / pack_installed /
+	 *     pack_active booleans and the resolved installed host plugin name.
+	 */
+	public static function match_installed( array $entries ): array {
+		$installed = self::installed_plugins();
+
+		$matches = array();
+		foreach ( $entries as $entry ) {
+			$host_key = self::find_installed_key( $entry['host_plugin_slug'], $installed );
+			if ( null === $host_key ) {
+				continue;
+			}
+
+			$pack_key = '' !== $entry['ability_pack_slug']
+				? self::find_installed_key( $entry['ability_pack_slug'], $installed )
+				: null;
+
+			$matches[] = array(
+				'entry'             => $entry,
+				'host_plugin_file'  => $host_key,
+				'host_plugin_name'  => (string) ( $installed[ $host_key ]['Name'] ?? $entry['host_plugin_name'] ),
+				'host_active'       => self::is_active( $host_key ),
+				'pack_installed'    => null !== $pack_key,
+				'pack_active'       => null !== $pack_key && self::is_active( $pack_key ),
+			);
+		}
+
+		return $matches;
+	}
+
+	/**
+	 * Convenience: fetch (cache-aware) and match in one call.
+	 *
+	 * @param bool $force Force a network refresh.
+	 *
+	 * @return array{
+	 *     matches: array<int,array<string,mixed>>,
+	 *     stale: bool,
+	 *     error: string,
+	 *     url: string,
+	 *     total: int
+	 * }
+	 */
+	public static function matches( bool $force = false ): array {
+		$result = self::get( $force );
+
+		return array(
+			'matches' => self::match_installed( $result['entries'] ),
+			'stale'   => $result['stale'],
+			'error'   => $result['error'],
+			'url'     => $result['url'],
+			'total'   => count( $result['entries'] ),
+		);
+	}
+
+	/**
+	 * All installed plugins, keyed by plugin file (e.g. "woocommerce/woocommerce.php").
+	 *
+	 * @return array<string,array<string,mixed>>
+	 */
+	private static function installed_plugins(): array {
+		if ( ! function_exists( 'get_plugins' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
+
+		return (array) get_plugins();
+	}
+
+	/**
+	 * Resolve a directory slug to an installed plugin file, tolerating slug
+	 * format differences (full "folder/file.php" path vs bare folder slug).
+	 *
+	 * @param string                            $slug      Directory-supplied slug.
+	 * @param array<string,array<string,mixed>> $installed get_plugins() output.
+	 *
+	 * @return string|null The matching plugin file key, or null when not installed.
+	 */
+	private static function find_installed_key( string $slug, array $installed ): ?string {
+		$slug = trim( $slug );
+		if ( '' === $slug ) {
+			return null;
+		}
+
+		// 1. Exact "folder/file.php" match.
+		if ( isset( $installed[ $slug ] ) ) {
+			return $slug;
+		}
+
+		// 2. Treat the supplied value as a folder slug and match on dirname,
+		//    or on the file stem for single-file plugins ("hello.php").
+		$needle = self::folder_slug( $slug );
+		foreach ( array_keys( $installed ) as $file ) {
+			if ( self::folder_slug( $file ) === $needle ) {
+				return $file;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Reduce a plugin file or slug to its comparable folder slug.
+	 *
+	 * "woocommerce/woocommerce.php" → "woocommerce"
+	 * "woocommerce"                 → "woocommerce"
+	 * "hello.php"                   → "hello"
+	 */
+	private static function folder_slug( string $value ): string {
+		$value = trim( $value );
+		if ( false !== strpos( $value, '/' ) ) {
+			return dirname( $value );
+		}
+
+		// Single-file plugin or bare slug: strip a trailing ".php".
+		return preg_replace( '/\.php$/', '', $value ) ?? $value;
+	}
+
+	/**
+	 * Whether a plugin file is active (site-wide or, on multisite, network-active).
+	 */
+	private static function is_active( string $plugin_file ): bool {
+		if ( ! function_exists( 'is_plugin_active' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
+
+		return is_plugin_active( $plugin_file );
+	}
+}

--- a/plugin/src/Services/PluginDirectory.php
+++ b/plugin/src/Services/PluginDirectory.php
@@ -222,8 +222,10 @@ final class PluginDirectory {
 	/**
 	 * Validate + normalize a single directory entry, or null if it is unusable.
 	 *
-	 * Required: host_plugin_slug, ability_pack_name. Everything else is
-	 * optional and defaulted to an empty string.
+	 * Required: target_plugin, ability_pack_name. Everything else is optional and
+	 * defaulted to an empty string. `target_plugin` is the WP plugin the pack
+	 * extends — the same value a pack declares in its `Agent Connector Target:`
+	 * header.
 	 *
 	 * @param mixed $item Raw entry.
 	 *
@@ -234,14 +236,14 @@ final class PluginDirectory {
 			return null;
 		}
 
-		$host_slug = isset( $item['host_plugin_slug'] ) && is_string( $item['host_plugin_slug'] )
-			? trim( $item['host_plugin_slug'] )
+		$target = isset( $item['target_plugin'] ) && is_string( $item['target_plugin'] )
+			? trim( $item['target_plugin'] )
 			: '';
 		$pack_name = isset( $item['ability_pack_name'] ) && is_string( $item['ability_pack_name'] )
 			? trim( $item['ability_pack_name'] )
 			: '';
 
-		if ( '' === $host_slug || '' === $pack_name ) {
+		if ( '' === $target || '' === $pack_name ) {
 			return null;
 		}
 
@@ -250,8 +252,8 @@ final class PluginDirectory {
 		};
 
 		return array(
-			'host_plugin_slug' => $host_slug,
-			'host_plugin_name' => $str( $item['host_plugin_name'] ?? '' ),
+			'target_plugin'      => $target,
+			'target_plugin_name' => $str( $item['target_plugin_name'] ?? '' ),
 			'ability_pack_slug' => $str( $item['ability_pack_slug'] ?? '' ),
 			'ability_pack_name' => $pack_name,
 			'source_url'        => $str( $item['source_url'] ?? '' ),
@@ -266,16 +268,16 @@ final class PluginDirectory {
 	 * @param array<int,array<string,string>> $entries Normalized directory entries.
 	 *
 	 * @return array<int,array<string,mixed>> One row per match, each with the
-	 *     directory entry plus host_installed / host_active / pack_installed /
-	 *     pack_active booleans and the resolved installed host plugin name.
+	 *     directory entry plus target_plugin_file / target_plugin_name /
+	 *     target_active and pack_installed / pack_active booleans.
 	 */
 	public static function match_installed( array $entries ): array {
 		$installed = self::installed_plugins();
 
 		$matches = array();
 		foreach ( $entries as $entry ) {
-			$host_key = self::find_installed_key( $entry['host_plugin_slug'], $installed );
-			if ( null === $host_key ) {
+			$target_key = self::find_installed_key( $entry['target_plugin'], $installed );
+			if ( null === $target_key ) {
 				continue;
 			}
 
@@ -284,10 +286,10 @@ final class PluginDirectory {
 				: null;
 
 			$matches[] = array(
-				'entry'             => $entry,
-				'host_plugin_file'  => $host_key,
-				'host_plugin_name'  => (string) ( $installed[ $host_key ]['Name'] ?? $entry['host_plugin_name'] ),
-				'host_active'       => self::is_active( $host_key ),
+				'entry'              => $entry,
+				'target_plugin_file' => $target_key,
+				'target_plugin_name' => (string) ( $installed[ $target_key ]['Name'] ?? $entry['target_plugin_name'] ),
+				'target_active'      => self::is_active( $target_key ),
 				'pack_installed'    => null !== $pack_key,
 				'pack_active'       => null !== $pack_key && self::is_active( $pack_key ),
 			);

--- a/plugin/src/Services/SandboxLoader.php
+++ b/plugin/src/Services/SandboxLoader.php
@@ -1,0 +1,243 @@
+<?php
+/**
+ * Loads AI-written PHP "plugins" from the sandbox directory each request, with
+ * crash recovery (safe mode) and an admin recovery flow.
+ *
+ * @package AgentConnectorForWp
+ */
+
+declare( strict_types=1 );
+
+namespace AgentConnectorForWp\Services;
+
+use AgentConnectorForWp\Support\Config;
+use AgentConnectorForWp\Support\Sandbox;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Auto-loads every *.php file in the sandbox directory, while protecting the
+ * site from a sandbox file that fatals.
+ *
+ * Crash recovery works via register_shutdown_function: while a sandbox file is
+ * loading we record which file it is, and on shutdown we check error_get_last()
+ * for a fatal. If one occurred we drop a `.crashed` marker (JSON) and, on every
+ * subsequent request, enter SAFE MODE — skipping all sandbox files — until an
+ * administrator fixes/deletes the offending file and clears the marker.
+ *
+ * The currently-loading file is tracked so a fatal thrown *deeper* in the call
+ * chain (a sandbox file calling into core or a third-party plugin that fatals)
+ * is still attributed to the sandbox file that triggered it.
+ */
+final class SandboxLoader {
+
+	/**
+	 * Query parameter to force safe mode for a single request without writing a
+	 * marker (e.g. to load wp-admin and clear a marker manually).
+	 */
+	private const SAFE_MODE_PARAM = 'acfw_safe_mode';
+
+	/**
+	 * admin-post action that deletes the .crashed marker to leave safe mode.
+	 */
+	public const CLEAR_ACTION = 'agent_connector_for_wp_clear_safe_mode';
+
+	/**
+	 * The sandbox file currently being required, or null when no file is loading.
+	 *
+	 * A reference to this is closed over by the shutdown handler; setting it back
+	 * to null after the load loop makes the handler a no-op for unrelated fatals.
+	 */
+	private ?string $current_file = null;
+
+	/**
+	 * Run the loader. Called once, early, on boot.
+	 *
+	 * Registers the admin notice + recovery handler unconditionally (so operators
+	 * can always recover), then either skips loading (safe mode) or loads the
+	 * sandbox files with crash detection armed.
+	 */
+	public function run(): void {
+		add_action( 'admin_post_' . self::CLEAR_ACTION, array( $this, 'handle_clear_safe_mode' ) );
+
+		if ( ! Sandbox::ensure_dir() ) {
+			return;
+		}
+
+		$is_safe_mode = $this->is_safe_mode();
+
+		// Tell operators why their sandbox files aren't running, and how to recover.
+		if ( $is_safe_mode ) {
+			add_action( 'admin_notices', array( $this, 'render_safe_mode_notice' ) );
+		}
+
+		if ( $is_safe_mode ) {
+			return;
+		}
+
+		$files = glob( Sandbox::dir() . '*.php' );
+		if ( empty( $files ) ) {
+			return;
+		}
+
+		register_shutdown_function( array( $this, 'detect_crash_on_shutdown' ) );
+
+		foreach ( $files as $file ) {
+			$this->current_file = $file;
+			require_once $file;
+		}
+
+		// Loading completed cleanly; disarm the crash handler for the rest of the
+		// request so an unrelated later fatal isn't blamed on the sandbox.
+		$this->current_file = null;
+	}
+
+	/**
+	 * Whether this request should run in safe mode: a persisted `.crashed` marker
+	 * exists, or safe mode was forced via the query parameter.
+	 */
+	public function is_safe_mode(): bool {
+		if ( file_exists( $this->crashed_marker_path() ) ) {
+			return true;
+		}
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- read-only toggle, no state change.
+		return isset( $_GET[ self::SAFE_MODE_PARAM ] ) && '1' === $_GET[ self::SAFE_MODE_PARAM ];
+	}
+
+	/**
+	 * Shutdown callback: if a fatal happened while a sandbox file was loading,
+	 * persist a `.crashed` marker so the next request enters safe mode.
+	 */
+	public function detect_crash_on_shutdown(): void {
+		// No sandbox file was loading when the request ended → not our crash.
+		if ( null === $this->current_file ) {
+			return;
+		}
+
+		$error = error_get_last();
+		if ( null === $error ) {
+			return;
+		}
+
+		// Only the fatal error types that actually kill execution.
+		$fatal = E_ERROR | E_PARSE | E_CORE_ERROR | E_COMPILE_ERROR;
+		if ( 0 === ( (int) $error['type'] & $fatal ) ) {
+			return;
+		}
+
+		$error['sandbox_file'] = $this->current_file;
+		$json                  = wp_json_encode( $error );
+		if ( false === $json ) {
+			$json = '{}';
+		}
+
+		// Suppress errors: we're already in shutdown after a fatal.
+		@file_put_contents( $this->crashed_marker_path(), $json, LOCK_EX ); // phpcs:ignore WordPress.PHP.NoSilencedErrors,WordPress.WP.AlternativeFunctions
+	}
+
+	/**
+	 * Admin notice shown to capable users while safe mode is active, explaining
+	 * what crashed and how to recover.
+	 */
+	public function render_safe_mode_notice(): void {
+		if ( ! current_user_can( Config::CAP ) ) {
+			return;
+		}
+
+		$marker  = $this->crashed_marker_path();
+		$crashed = file_exists( $marker );
+
+		$details = '';
+		if ( $crashed ) {
+			$raw  = (string) @file_get_contents( $marker ); // phpcs:ignore WordPress.PHP.NoSilencedErrors,WordPress.WP.AlternativeFunctions
+			$data = json_decode( $raw, true );
+			if ( is_array( $data ) && ! empty( $data['sandbox_file'] ) ) {
+				$file    = (string) $data['sandbox_file'];
+				$message = isset( $data['message'] ) ? (string) $data['message'] : '';
+				$details = sprintf(
+					' %s <code>%s</code>%s',
+					esc_html__( 'The crash was attributed to:', 'agent-connector-for-wp' ),
+					esc_html( $file ),
+					'' === $message ? '' : ' — ' . esc_html( $message )
+				);
+			}
+		}
+
+		$clear_button = '';
+		if ( $crashed ) {
+			$clear_button = sprintf(
+				'<form method="post" action="%1$s" style="display:inline;margin-left:.5em;"><input type="hidden" name="action" value="%2$s" />%3$s%4$s</form>',
+				esc_url( admin_url( 'admin-post.php' ) ),
+				esc_attr( self::CLEAR_ACTION ),
+				wp_nonce_field( self::CLEAR_ACTION, '_wpnonce', true, false ),
+				sprintf(
+					'<button type="submit" class="button button-small">%s</button>',
+					esc_html__( 'Clear safe mode', 'agent-connector-for-wp' )
+				)
+			);
+		}
+
+		printf(
+			'<div class="notice notice-error"><p><strong>%1$s</strong> %2$s%3$s</p><p>%4$s%5$s</p></div>',
+			esc_html__( 'Agent Connector for WP — sandbox safe mode is active.', 'agent-connector-for-wp' ),
+			esc_html__( 'A sandbox PHP file caused a fatal error, so all sandbox files are temporarily disabled to keep the site up.', 'agent-connector-for-wp' ),
+			wp_kses( $details, array( 'code' => array() ) ),
+			esc_html__( 'To recover: fix or delete the broken file in the sandbox directory, then clear safe mode by deleting the ".crashed" marker (or use the button).', 'agent-connector-for-wp' ),
+			wp_kses(
+				$clear_button,
+				array(
+					'form'   => array(
+						'method' => array(),
+						'action' => array(),
+						'style'  => array(),
+					),
+					'input'  => array(
+						'type'  => array(),
+						'name'  => array(),
+						'value' => array(),
+						'id'    => array(),
+					),
+					'button' => array(
+						'type'  => array(),
+						'class' => array(),
+					),
+				)
+			)
+		);
+	}
+
+	/**
+	 * admin-post: delete the `.crashed` marker to leave safe mode.
+	 *
+	 * Mirrors ConnectionPage's handler style: cap + nonce check, then redirect
+	 * back with a status flag.
+	 */
+	public function handle_clear_safe_mode(): void {
+		if ( ! current_user_can( Config::CAP ) ) {
+			wp_die( esc_html__( 'You do not have permission to do this.', 'agent-connector-for-wp' ), '', array( 'response' => 403 ) );
+		}
+		check_admin_referer( self::CLEAR_ACTION );
+
+		$marker = $this->crashed_marker_path();
+		$ok     = ! file_exists( $marker ) || @unlink( $marker ); // phpcs:ignore WordPress.PHP.NoSilencedErrors
+
+		wp_safe_redirect(
+			add_query_arg(
+				array(
+					'page'        => 'agent-connector-for-wp',
+					'acfw_notice' => $ok ? 'safe_mode_cleared' : 'safe_mode_clear_failed',
+				),
+				admin_url( 'admin.php' )
+			)
+		);
+		exit;
+	}
+
+	/**
+	 * Absolute path to the `.crashed` marker.
+	 */
+	private function crashed_marker_path(): string {
+		return Sandbox::dir() . '.crashed';
+	}
+}

--- a/plugin/src/Services/WrappedHandler.php
+++ b/plugin/src/Services/WrappedHandler.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Marker wrapper around an ability execute callback.
+ *
+ * @package AgentConnectorForWp
+ */
+
+declare( strict_types=1 );
+
+namespace AgentConnectorForWp\Services;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * An invokable that wraps an ability's execute callback with the plugin's
+ * domain-lock enforcement and audit logging (see AuditLogger::wrap()).
+ *
+ * It exists as a concrete class — rather than a plain closure — purely so the
+ * governance layer can recognize an already-wrapped callback (`instanceof`) and
+ * never wrap it a second time. Double-wrapping would double-log and run the
+ * domain-lock check twice; the marker makes the chokepoint idempotent.
+ *
+ * Being invokable, it is itself `callable` and drops in anywhere a closure
+ * execute_callback was used before.
+ */
+final class WrappedHandler {
+
+	/**
+	 * The ability name, used for the audit-log line.
+	 *
+	 * @var string
+	 */
+	private $ability;
+
+	/**
+	 * The underlying ability handler: fn(array $input): mixed|WP_Error.
+	 *
+	 * @var callable
+	 */
+	private $handler;
+
+	/**
+	 * Optional redaction callback for the audit log: fn(array $input): array.
+	 *
+	 * @var callable|null
+	 */
+	private $summarizer;
+
+	/**
+	 * @param string        $ability    Ability name, e.g. my-plugin/do-thing.
+	 * @param callable      $handler    fn(array $input): mixed|WP_Error.
+	 * @param callable|null $summarizer fn(array $input): array — a redacted summary for the log.
+	 */
+	public function __construct( string $ability, callable $handler, ?callable $summarizer = null ) {
+		$this->ability    = $ability;
+		$this->handler    = $handler;
+		$this->summarizer = $summarizer;
+	}
+
+	/**
+	 * Invoke the wrapped handler with domain-lock enforcement + audit logging.
+	 *
+	 * @param array<string,mixed> $input Ability input.
+	 * @return mixed|\WP_Error
+	 */
+	public function __invoke( $input = array() ) {
+		return AuditLogger::run( $this->ability, $this->handler, $this->summarizer, $input );
+	}
+}

--- a/plugin/src/Support/Governance.php
+++ b/plugin/src/Support/Governance.php
@@ -1,0 +1,145 @@
+<?php
+/**
+ * Governance: force OUR auth, domain-lock, and audit onto every ability our MCP
+ * server will expose — no matter who registered it.
+ *
+ * @package AgentConnectorForWp
+ */
+
+declare( strict_types=1 );
+
+namespace AgentConnectorForWp\Support;
+
+use AgentConnectorForWp\Services\AuditLogger;
+use AgentConnectorForWp\Services\WrappedHandler;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Single chokepoint that guarantees no ability reachable through our MCP server
+ * uses anyone else's (or no) authentication.
+ *
+ * The default WordPress MCP server (wordpress/mcp-adapter) auto-exposes ANY
+ * ability whose meta carries `mcp.public === true`, regardless of which plugin
+ * registered it. That is convenient — but it means a third party could register
+ * a public ability with `permission_callback => __return_true` and bypass our
+ * admin/super-admin gate. To prevent that, this layer hooks the core
+ * `wp_register_ability_args` filter (which fires for EVERY `wp_register_ability()`
+ * call) and, for every ability that will be MCP-exposed, rewrites its arguments
+ * before the WP_Ability object is built:
+ *
+ *   1. permission_callback  → our {@see Config::has_admin_access()} check
+ *      (overriding whatever the registrant supplied), and
+ *   2. execute_callback     → wrapped with {@see AuditLogger::wrap()} so the
+ *      domain lock is enforced and the call is audit-logged.
+ *
+ * Working on the plain `$args` array (pre-construction) means no reflection and
+ * no re-registration: the override is simply the last word before WP_Ability is
+ * instantiated.
+ *
+ * Built-in abilities already wrap their own execute callback (via
+ * AuditLogger::wrap, which returns a {@see WrappedHandler}); this layer detects
+ * that marker and does not wrap a second time, so there is no double-logging.
+ * Overriding their permission_callback with the identical check is a no-op.
+ */
+final class Governance {
+
+	/**
+	 * Register the governance filter. Idempotent — safe to call more than once.
+	 */
+	public static function register(): void {
+		// Priority 99: run late so it wins over anything a registrant added to
+		// the same filter, but still before WP_Ability is constructed.
+		if ( ! has_filter( 'wp_register_ability_args', array( self::class, 'enforce' ) ) ) {
+			add_filter( 'wp_register_ability_args', array( self::class, 'enforce' ), 99, 2 );
+		}
+	}
+
+	/**
+	 * Rewrite an ability's args to enforce our auth + audit, if it will be
+	 * exposed over our MCP server.
+	 *
+	 * @param array<string,mixed> $args The ability registration arguments.
+	 * @param string              $name The ability name, with namespace.
+	 * @return array<string,mixed> The (possibly) governed arguments.
+	 */
+	public static function enforce( $args, $name ): array {
+		$args = is_array( $args ) ? $args : array();
+		$name = is_string( $name ) ? $name : '';
+
+		if ( ! self::should_govern( $args, $name ) ) {
+			return $args;
+		}
+
+		// (1) Force OUR permission callback. Whatever the registrant supplied
+		// (including __return_true or nothing) is discarded.
+		$args['permission_callback'] = array( Config::class, 'has_admin_access' );
+
+		// (2) Ensure the execute callback runs through OUR domain-lock + audit
+		// chokepoint — unless it already does (built-ins), to avoid double work.
+		if ( isset( $args['execute_callback'] ) && is_callable( $args['execute_callback'] ) && ! ( $args['execute_callback'] instanceof WrappedHandler ) ) {
+			$summarizer               = self::extract_summarizer( $args );
+			$args['execute_callback'] = AuditLogger::wrap( $name, $args['execute_callback'], $summarizer );
+		}
+
+		// Clean up our own private key so it never lands in WP_Ability args
+		// (which would trigger an "invalid property" doing-it-wrong notice).
+		unset( $args['acfw_summarize'] );
+
+		return $args;
+	}
+
+	/**
+	 * Whether this ability will be exposed over our MCP server and therefore
+	 * must be governed.
+	 *
+	 * An ability is MCP-exposed when its meta carries `mcp.public === true` — the
+	 * exact flag the adapter's DefaultServerFactory keys on. Integrators can
+	 * exempt specific ability names through the `agent_connector_for_wp_govern_ability`
+	 * filter (default: govern everything public).
+	 *
+	 * @param array<string,mixed> $args The ability registration arguments.
+	 * @param string              $name The ability name.
+	 */
+	private static function should_govern( array $args, string $name ): bool {
+		$is_public = isset( $args['meta']['mcp']['public'] ) && true === $args['meta']['mcp']['public'];
+
+		/**
+		 * Filters whether a given MCP-exposed ability is governed by Agent
+		 * Connector's auth / domain-lock / audit chokepoint.
+		 *
+		 * Defaults to true for every ability that is exposed over our MCP server
+		 * (mcp.public === true) and false for everything else. Return false for a
+		 * specific name only if an integrator deliberately wants to take over
+		 * authentication for that ability — doing so means our admin gate, domain
+		 * lock, and audit log no longer apply to it.
+		 *
+		 * @since 1.4.0
+		 *
+		 * @param bool                $govern Whether to govern this ability. Default = is it MCP-public.
+		 * @param string              $name   The ability name, with namespace.
+		 * @param array<string,mixed> $args   The ability registration arguments.
+		 */
+		return (bool) apply_filters( 'agent_connector_for_wp_govern_ability', $is_public, $name, $args );
+	}
+
+	/**
+	 * Pull a summarize/redaction callback out of the args, if one was provided.
+	 *
+	 * Accepts either `acfw_summarize` (the key our public registration helper
+	 * uses) or a `meta.acfw.summarize` callback, so a raw third-party
+	 * registration can opt into audit redaction too.
+	 *
+	 * @param array<string,mixed> $args The ability registration arguments.
+	 * @return callable|null
+	 */
+	private static function extract_summarizer( array $args ): ?callable {
+		if ( isset( $args['acfw_summarize'] ) && is_callable( $args['acfw_summarize'] ) ) {
+			return $args['acfw_summarize'];
+		}
+		if ( isset( $args['meta']['acfw']['summarize'] ) && is_callable( $args['meta']['acfw']['summarize'] ) ) {
+			return $args['meta']['acfw']['summarize'];
+		}
+		return null;
+	}
+}

--- a/plugin/src/Support/Sandbox.php
+++ b/plugin/src/Support/Sandbox.php
@@ -1,0 +1,171 @@
+<?php
+/**
+ * Sandbox path model: where AI-written PHP lives and how the PHP-execution
+ * boundary is enforced.
+ *
+ * @package AgentConnectorForWp
+ */
+
+declare( strict_types=1 );
+
+namespace AgentConnectorForWp\Support;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * The sandbox is an *operational* boundary for generated PHP, not a security
+ * isolation boundary for all filesystem writes.
+ *
+ * It gives the plugin one place to load AI-written PHP "plugins" from, disable
+ * them, and recover from crashes (see Services\SandboxLoader). Authenticated
+ * administrators may still read, write, and delete *non-PHP* files anywhere on
+ * the filesystem — that is part of the plugin's high-trust model. What this
+ * class enforces is narrower: files that can directly affect PHP execution
+ * (.php, plus a short list of execution-control files) may only be written
+ * inside the sandbox directory, so generated code has a single, recoverable
+ * home rather than being scattered across the install.
+ */
+final class Sandbox {
+
+	/**
+	 * Filenames (lowercased) that aren't .php but can still alter how PHP runs,
+	 * so they are confined to the sandbox like .php files.
+	 *
+	 * @var array<int,string>
+	 */
+	private const PHP_EXECUTION_CONTROL_FILES = array(
+		'.htaccess',
+		'.user.ini',
+		'php.ini',
+		'.php.ini',
+		'web.config',
+	);
+
+	/**
+	 * Absolute path to the sandbox directory, with a trailing slash.
+	 *
+	 * Override with the AGENT_CONNECTOR_FOR_WP_SANDBOX_DIR constant; otherwise it
+	 * lives under wp-content so it survives core/plugin updates.
+	 */
+	public static function dir(): string {
+		if ( defined( 'AGENT_CONNECTOR_FOR_WP_SANDBOX_DIR' ) && is_string( AGENT_CONNECTOR_FOR_WP_SANDBOX_DIR ) ) {
+			return trailingslashit( AGENT_CONNECTOR_FOR_WP_SANDBOX_DIR );
+		}
+		return rtrim( WP_CONTENT_DIR, '/\\' ) . '/agent-connector-for-wp-sandbox/';
+	}
+
+	/**
+	 * Ensure the sandbox directory exists. Best-effort: returns whether it's a
+	 * directory afterwards.
+	 */
+	public static function ensure_dir(): bool {
+		$dir = self::dir();
+		if ( is_dir( $dir ) ) {
+			return true;
+		}
+		return (bool) wp_mkdir_p( $dir );
+	}
+
+	/**
+	 * Whether a path can directly affect PHP execution and must therefore stay
+	 * inside the sandbox.
+	 *
+	 * Deliberately narrow — do not broaden this to every writable file, or the
+	 * general filesystem abilities stop working. It's only .php and the handful
+	 * of files that change how PHP itself runs.
+	 */
+	public static function path_requires_sandbox( string $path ): bool {
+		$extension = strtolower( (string) pathinfo( $path, PATHINFO_EXTENSION ) );
+		if ( 'php' === $extension ) {
+			return true;
+		}
+
+		$filename = strtolower( basename( $path ) );
+		return in_array( $filename, self::PHP_EXECUTION_CONTROL_FILES, true );
+	}
+
+	/**
+	 * Enforce the PHP-execution boundary for a resolved write target.
+	 *
+	 * Returns true for ordinary (non-PHP) paths — those are allowed anywhere by
+	 * design. For PHP-execution paths it returns an agent-actionable WP_Error
+	 * unless the file's parent directory is inside the sandbox.
+	 *
+	 * @param string $resolved Absolute, resolved destination path.
+	 * @return true|\WP_Error
+	 */
+	public static function check_php_execution_boundary( string $resolved ) {
+		if ( ! self::path_requires_sandbox( $resolved ) ) {
+			return true;
+		}
+
+		$sandbox = self::normalize_boundary( self::real_or_self( self::dir() ) );
+		// Compare the *parent* directory so a brand-new file (which doesn't
+		// resolve yet) is still judged by where it would land.
+		$parent  = self::normalize_boundary( self::real_or_self( dirname( $resolved ) ) );
+
+		if ( ! self::is_within( $parent, $sandbox ) ) {
+			return new \WP_Error(
+				'agent_connector_for_wp_php_sandbox_required',
+				sprintf(
+					'PHP files and PHP-execution control files (.php, .htaccess, .user.ini, php.ini, web.config) can only be written inside the sandbox directory: %1$s. Write generated PHP there instead — e.g. a path like "%2$smy-feature.php".',
+					self::dir(),
+					self::dir()
+				),
+				array( 'status' => 403 )
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Reject a write whose final path is a symlink, so an agent can't be tricked
+	 * (or trick itself) into writing through a link that escapes the intended
+	 * target.
+	 *
+	 * @param string $resolved Absolute, resolved destination path.
+	 * @return true|\WP_Error
+	 */
+	public static function reject_final_symlink( string $resolved ) {
+		if ( ! is_link( $resolved ) ) {
+			return true;
+		}
+
+		return new \WP_Error(
+			'agent_connector_for_wp_symlink_write_rejected',
+			sprintf( 'Refusing to write through a symlinked path: %s', $resolved ),
+			array( 'status' => 403 )
+		);
+	}
+
+	/**
+	 * realpath() with a graceful fallback to the input when the path doesn't
+	 * exist yet (new files, sandbox not created).
+	 */
+	private static function real_or_self( string $path ): string {
+		$real = realpath( $path );
+		return false === $real ? $path : $real;
+	}
+
+	/**
+	 * Normalize separators and strip a trailing slash for boundary comparisons.
+	 */
+	private static function normalize_boundary( string $path ): string {
+		$normalized = rtrim( str_replace( '\\', '/', $path ), '/' );
+		return '' === $normalized ? '/' : $normalized;
+	}
+
+	/**
+	 * Whether a normalized path is the boundary directory itself or sits under it.
+	 */
+	private static function is_within( string $path, string $directory ): bool {
+		if ( $path === $directory ) {
+			return true;
+		}
+		if ( '/' === $directory ) {
+			return str_starts_with( $path, '/' );
+		}
+		return str_starts_with( $path, $directory . '/' );
+	}
+}

--- a/plugin/src/api.php
+++ b/plugin/src/api.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * Public registration API for third-party "ability pack" plugins.
+ *
+ * This is the one stable, documented entry point a companion plugin uses to
+ * register a WordPress ability that is exposed over Agent Connector's MCP server
+ * and automatically protected by Agent Connector's authentication, domain lock,
+ * and audit logging. The companion plugin writes NO permission / auth /
+ * domain-lock / audit code.
+ *
+ * See docs/registering-abilities.md for the full developer guide.
+ *
+ * The functions live in the global namespace on purpose: companion plugins call
+ * them directly, with no `use` statement and no knowledge of internal classes.
+ *
+ * @package AgentConnectorForWp
+ */
+
+declare( strict_types=1 );
+
+defined( 'ABSPATH' ) || exit;
+
+if ( ! function_exists( 'agent_connector_for_wp_register_ability' ) ) {
+	/**
+	 * Register a WordPress ability and expose it, protected, over Agent
+	 * Connector's MCP server.
+	 *
+	 * Thin wrapper over core `wp_register_ability()`. The caller supplies only the
+	 * ability's identity and behavior; Agent Connector force-injects everything
+	 * security-related:
+	 *
+	 *   - permission_callback — our administrator / super-admin gate. Any value
+	 *     the caller passes for `permission_callback` is IGNORED and overridden.
+	 *   - domain lock + audit logging — the execute callback is wrapped so calls
+	 *     are blocked when the site's domain lock is tripped and every invocation
+	 *     is recorded to the audit log.
+	 *   - MCP exposure — `meta.mcp.public` and `meta.show_in_rest` are forced on
+	 *     so the bundled mcp-adapter surfaces the ability.
+	 *
+	 * Must be called on (or before) the `wp_abilities_api_init` action, exactly
+	 * like `wp_register_ability()`. The ability's `category` must already be
+	 * registered (register it on `wp_abilities_api_categories_init`).
+	 *
+	 * @since 1.4.0
+	 *
+	 * @param string               $name The ability name, with the CALLER's own
+	 *                                    vendor namespace, e.g. "my-plugin/do-thing".
+	 *                                    Lowercase alphanumerics, dashes, one slash.
+	 * @param array<string,mixed>  $args {
+	 *     Ability definition. Same shape as wp_register_ability() minus the auth.
+	 *
+	 *     @type string               $label            Required. Human-readable label.
+	 *     @type string               $description      Required. What the ability does (the agent reads this).
+	 *     @type string               $category         Required. A registered ability-category slug.
+	 *     @type array<string,mixed>  $input_schema     JSON Schema for the input object. Strongly recommended.
+	 *     @type array<string,mixed>  $output_schema    JSON Schema for the result object. Recommended.
+	 *     @type callable             $execute_callback Required. fn(array $input): array|WP_Error.
+	 *     @type callable             $summarize        Optional. fn(array $input): array — a REDACTED
+	 *                                                  summary of the input for the audit log. Use this to
+	 *                                                  keep secrets / large blobs out of the log. If omitted,
+	 *                                                  nothing from the input is logged.
+	 *     @type array<string,mixed>  $meta             Optional. Extra ability meta (e.g. `annotations`).
+	 *                                                  Any `mcp.public` / `show_in_rest` you set is overridden.
+	 *     @type array<string,mixed>  $annotations      Optional. Shorthand for `meta.annotations`
+	 *                                                  (readonly / destructive / idempotent hints).
+	 *     @type callable             $permission_callback IGNORED. Auth is owned by Agent Connector.
+	 * }
+	 * @return void
+	 */
+	function agent_connector_for_wp_register_ability( string $name, array $args ): void {
+		if ( ! function_exists( 'wp_register_ability' ) ) {
+			return;
+		}
+
+		// Normalize meta and fold in the optional `annotations` shorthand.
+		$meta = isset( $args['meta'] ) && is_array( $args['meta'] ) ? $args['meta'] : array();
+		if ( isset( $args['annotations'] ) && is_array( $args['annotations'] ) ) {
+			$meta['annotations'] = array_merge(
+				isset( $meta['annotations'] ) && is_array( $meta['annotations'] ) ? $meta['annotations'] : array(),
+				$args['annotations']
+			);
+		}
+		unset( $args['annotations'] );
+
+		// Force MCP exposure so the adapter surfaces this ability.
+		$meta['mcp']          = array_merge(
+			isset( $meta['mcp'] ) && is_array( $meta['mcp'] ) ? $meta['mcp'] : array(),
+			array( 'public' => true )
+		);
+		$meta['show_in_rest'] = true;
+		$args['meta']         = $meta;
+
+		// The caller does NOT own auth. Drop anything they passed; Governance
+		// injects our permission callback for every MCP-public ability.
+		unset( $args['permission_callback'] );
+
+		// Hand the redaction summarizer to the governance/audit chokepoint under
+		// our private key. Governance consumes it when it wraps the handler and
+		// strips the key before WP_Ability is constructed.
+		if ( isset( $args['summarize'] ) && is_callable( $args['summarize'] ) ) {
+			$args['acfw_summarize'] = $args['summarize'];
+		}
+		unset( $args['summarize'] );
+
+		// Register via core. The execute_callback is wrapped, and the permission
+		// callback injected, by AgentConnectorForWp\Support\Governance on the
+		// `wp_register_ability_args` filter — the same chokepoint built-ins use.
+		wp_register_ability( $name, $args );
+	}
+}
+
+if ( ! function_exists( 'acfw_register_ability' ) ) {
+	/**
+	 * Short alias for {@see agent_connector_for_wp_register_ability()}.
+	 *
+	 * @since 1.4.0
+	 *
+	 * @param string              $name The ability name, with the caller's vendor namespace.
+	 * @param array<string,mixed> $args Ability definition. See the canonical function.
+	 * @return void
+	 */
+	function acfw_register_ability( string $name, array $args ): void {
+		agent_connector_for_wp_register_ability( $name, $args );
+	}
+}


### PR DESCRIPTION
Four independent capabilities, built in parallel and integrated on this branch. Master was untouched; this PR merges the four feature branches together.

## What's included

### 1. Sandbox (`feat/sandbox`)
Auto-loads AI-written PHP "plugins" from `wp-content/agent-connector-for-wp-sandbox/` on every request, with **crash recovery**: a shutdown handler attributes fatals to the loading file, writes a `.crashed` marker, and drops into safe mode (skips all sandbox files) until cleared. `FileManager::write()` now confines `.php`/`.htaccess`/`.user.ini`/`php.ini`/`web.config` to the sandbox dir and rejects writes through a final-path symlink; non-PHP writes elsewhere are unaffected.

### 2. GitHub self-updater (`feat/github-updater`)
Pulls updates from the GitHub repo via `yahnis-elsts/plugin-update-checker` (added with `composer require`, loads through the existing Jetpack autoloader). Configured for **GitHub Releases with `enableReleaseAssets()`** so it installs the built zip (which bundles `vendor/`) rather than the source tarball, which would fatal. Private-repo token supported later via the `agent_connector_for_wp_github_auth_token` filter / `AGENT_CONNECTOR_FOR_WP_GITHUB_TOKEN` constant.

### 3. Third-party ability API (`feat/ability-api`)
Public `agent_connector_for_wp_register_ability()` (+ `acfw_register_ability()` alias) lets any plugin register an MCP ability **without writing auth code**. A governance layer hooks core `wp_register_ability_args` and force-injects our permission check + domain-lock + audit logging onto *every* `mcp.public` ability — including raw third-party registrations that ship their own (or no) permission callback — so nothing reachable through the MCP server can bypass auth. `WrappedHandler` prevents double-wrapping built-ins. Full developer guide in `docs/registering-abilities.md` plus a runnable example pack.

### 4. Ability-pack directory (`feat/plugin-directory`)
Fetches a remote-hosted directory of companion "ability pack" plugins (cached 12h, graceful offline fallback) and shows, on a new **Ability Packs** admin page, which installed WordPress plugins have a pack available. URL overridable via `agent_connector_for_wp_directory_url`. Schema in `docs/directory-schema.md`.

## Known follow-up
Tasks 3 and 4 define the companion-plugin "target plugin" convention slightly differently (header-encoded vs. directory `host_plugin_slug` join key). Recommend adding an explicit `Agent Connector Target:` header and keying the directory on it. Not blocking.

## Verification
- `php -l` clean on all 12 changed/added PHP files.
- Each feature was logic-verified with stubbed harnesses (governance override, no double-wrap, sandbox path-escape, directory normalization).
- Live WordPress smoke test (activation, admin pages render, MCP server still exposes abilities) in progress.

## Maintainer notes
- Updater: updates flow once a GitHub Release with the built zip is cut (existing auto-release workflow handles this).
- Directory: point `agent_connector_for_wp_directory_url` at the real endpoint when it exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)