### PR TITLE
feat: install ability packs from the tracker + host-managed pack updates

### DIFF
--- a/plugin/agent-connector-for-wp.php
+++ b/plugin/agent-connector-for-wp.php
@@ -108,9 +108,13 @@ add_action(
 		// dangerous; the gates below still guard the MCP server and abilities.
 		if ( is_admin() ) {
 			( new Admin\ConnectionPage() )->register();
-			// Read-only browser of available companion "ability pack" plugins.
+			// Browser of available companion "ability pack" plugins (with install).
 			( new Admin\DirectoryPage() )->register();
 		}
+
+		// Keep installed ability packs updatable from GitHub in every context
+		// (admin + cron), independent of whether the plugin is switched "on".
+		( new Services\PackUpdater() )->register();
 
 		if ( ! Support\Config::can_boot() ) {
 			// Surface *why* it's off so the disabled state isn't a silent mystery.

--- a/plugin/docs/directory-schema.md
+++ b/plugin/docs/directory-schema.md
@@ -1,27 +1,38 @@
 # Ability-Pack Directory Schema
 
-Agent Connector for WP fetches a remote JSON **directory** of companion "ability
-pack" plugins and matches it against the plugins installed on a site, so an admin
-can see which of their plugins have an available ability pack.
+Agent Connector for WP asks a remote **match endpoint** which of the plugins
+installed on a site have a companion "ability pack" available, then lets the admin
+install/activate them and keeps them updated. By default that endpoint is the
+[agent-ready-plugins-tracker](../../agent-ready-plugins-tracker/) app, which serves
+the data from the GitHub `pack-index` manifest the release CI generates.
 
-- **Default URL:** `https://raw.githubusercontent.com/soflyy/agent-connector-for-wp-directory/main/directory.json`
-  (a **placeholder** — there is no live endpoint yet; point it at the real one).
+- **Default URL:** `https://agent-ready-plugins-tracker-git-master-future-layer.vercel.app/api/ability-packs/match`
+  (the endpoint must be **publicly reachable** — disable Vercel Deployment
+  Protection for it, or point the filter below at a public domain).
 - **Override filter:** `agent_connector_for_wp_directory_url`
   ```php
-  add_filter( 'agent_connector_for_wp_directory_url', fn() => 'https://example.com/directory.json' );
+  add_filter( 'agent_connector_for_wp_directory_url', fn() => 'https://example.com/api/ability-packs/match' );
   ```
-- **Caching:** fetched with `wp_remote_get` (5s timeout) and cached in the
-  `agent_connector_for_wp_directory_cache` transient for 12 hours. On a fetch
-  failure the last cached copy is reused (flagged "stale"); with no cache at all
-  the UI shows a clean "directory unavailable" state. A manual **Refresh now**
-  button busts the cache.
+- **Request:** `POST` (`wp_remote_post`, 5s timeout) with a JSON body listing the
+  site's installed plugins so the endpoint can return only relevant packs:
+  ```json
+  {
+    "site_url": "https://example.com",
+    "plugins": [
+      { "slug": "contact-form-7", "file": "contact-form-7/wp-contact-form-7.php", "active": true }
+    ]
+  }
+  ```
+- **Caching:** the response is cached in the
+  `agent_connector_for_wp_directory_cache` transient for 12 hours, fingerprinted by
+  the installed-plugin set (installing/removing a plugin invalidates it). On a fetch
+  failure the last cached copy is reused (flagged "stale"); with no cache at all the
+  UI shows a clean "directory unavailable" state. A manual **Refresh now** button
+  busts the cache.
 
-## Shape
+## Response shape
 
-Two accepted top-level forms; pick whichever you like:
-
-1. A bare JSON **array** of entry objects, or
-2. A JSON **object** with an `entries` array (room for future top-level metadata):
+A JSON **object** with an `entries` array (a bare array is also accepted):
 
 ```json
 {
@@ -42,6 +53,9 @@ The client normalizes both to the same internal list.
 | `source_url`        | no       | string | Where to get the pack (GitHub repo, wp.org page, etc.). Rendered as a link. |
 | `description`       | no       | string | One-line description shown in the table. |
 | `version`           | no       | string | Latest published version of the pack. |
+| `download_url`      | no       | string | Direct URL to the pack's installable `.zip` (a GitHub release asset). Required for the one-click **Install** button and for host-managed updates. Only `https` URLs on an allowlisted host (GitHub by default; filter `agent_connector_for_wp_pack_download_hosts`) are installed. |
+
+`ability_pack_name` may also be supplied as `name`.
 
 Entries missing either required field are **silently ignored**. All values are
 trimmed; non-string values are coerced to empty strings.
@@ -52,9 +66,16 @@ For each entry whose `target_plugin` resolves to an **installed** plugin
 (via `get_plugins()`), the UI shows a row with the installed plugin name, the
 ability pack (linked to `source_url`), and a status:
 
-- **Available to add** — host plugin installed, pack not installed.
-- **Installed, inactive** — `ability_pack_slug` is installed but not active.
+- **Available to add** — host plugin installed, pack not installed. Shows an
+  **Install** button (downloads `download_url`, installs, and activates).
+- **Installed, inactive** — `ability_pack_slug` is installed but not active. Shows
+  an **Activate** button.
 - **Installed & active** — `ability_pack_slug` is installed and active.
+
+Install/activate require the `install_plugins`/`activate_plugins` capabilities and a
+nonce; the download URL is re-resolved server-side from this directory (never from
+the browser). Once a pack is installed, the host keeps it updated by injecting its
+latest `version`/`download_url` into WordPress's normal plugin-update flow.
 
 Slug matching is robust to folder-vs-full-path differences and to single-file
 plugins (e.g. `hello.php` ⇄ `hello`).

--- a/plugin/docs/directory.json
+++ b/plugin/docs/directory.json
@@ -4,29 +4,22 @@
     {
       "target_plugin": "woocommerce/woocommerce.php",
       "target_plugin_name": "WooCommerce",
-      "ability_pack_slug": "agent-connector-woocommerce/agent-connector-woocommerce.php",
-      "ability_pack_name": "Agent Connector for WooCommerce",
-      "source_url": "https://github.com/soflyy/agent-connector-woocommerce",
+      "ability_pack_slug": "unofficial-abilities-for-woocommerce",
+      "ability_pack_name": "Unofficial Abilities for WooCommerce",
+      "source_url": "https://github.com/soflyy/agent-connector-for-wp/tree/master/ability-packs/unofficial-abilities-for-woocommerce",
+      "download_url": "https://github.com/soflyy/agent-connector-for-wp/releases/download/unofficial-abilities-for-woocommerce-v1.0.0/unofficial-abilities-for-woocommerce.zip",
       "description": "Exposes order, product, and customer abilities so agents can manage your store over MCP.",
       "version": "1.0.0"
     },
     {
       "target_plugin": "contact-form-7",
       "target_plugin_name": "Contact Form 7",
-      "ability_pack_slug": "agent-connector-cf7",
-      "ability_pack_name": "Agent Connector for Contact Form 7",
-      "source_url": "https://github.com/soflyy/agent-connector-cf7",
+      "ability_pack_slug": "unofficial-abilities-for-contact-form-7",
+      "ability_pack_name": "Unofficial Abilities for Contact Form 7",
+      "source_url": "https://github.com/soflyy/agent-connector-for-wp/tree/master/ability-packs/unofficial-abilities-for-contact-form-7",
+      "download_url": "https://github.com/soflyy/agent-connector-for-wp/releases/download/unofficial-abilities-for-contact-form-7-v0.1.0/unofficial-abilities-for-contact-form-7.zip",
       "description": "Lets agents read submissions and edit form definitions.",
-      "version": "0.3.1"
-    },
-    {
-      "target_plugin": "wordpress-seo/wp-seo.php",
-      "target_plugin_name": "Yoast SEO",
-      "ability_pack_slug": "agent-connector-yoast/agent-connector-yoast.php",
-      "ability_pack_name": "Agent Connector for Yoast SEO",
-      "source_url": "https://github.com/soflyy/agent-connector-yoast",
-      "description": "Abilities for auditing and updating per-post SEO metadata.",
-      "version": "0.9.0"
+      "version": "0.1.0"
     }
   ]
 }

--- a/plugin/docs/registering-abilities.md
+++ b/plugin/docs/registering-abilities.md
@@ -239,10 +239,9 @@ A companion plugin that exists to add abilities to a specific host MCP plugin is
 an **ability pack**. A remote directory feature discovers ability packs by their
 plugin header, so follow this convention exactly:
 
-1. **Slug / folder.** Name the plugin
-   `agent-connector-for-wp-ability-pack-<target>`, e.g.
-   `agent-connector-for-wp-ability-pack-woocommerce`. The folder, main file, and
-   `Plugin Name` should agree.
+1. **Slug / folder.** Name the plugin `unofficial-abilities-for-<target>`, e.g.
+   `unofficial-abilities-for-woocommerce`. The folder, main file, and `Plugin Name`
+   (`Unofficial Abilities for WooCommerce`) should agree.
 
 2. **Declare dependency, identity, and target.** Three header lines:
 
@@ -262,7 +261,7 @@ plugin header, so follow this convention exactly:
 
    ```php
    /**
-    * Plugin Name:       Agent Connector for WP Ability Pack: WooCommerce
+    * Plugin Name:       Unofficial Abilities for WooCommerce
     * Requires Plugins:  agent-connector-for-wp
     *
     * Agent Connector: Ability Pack

--- a/plugin/src/Admin/DirectoryPage.php
+++ b/plugin/src/Admin/DirectoryPage.php
@@ -16,24 +16,28 @@ use AgentConnectorForWp\Support\Config;
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Read-only directory browser.
+ * Ability-pack directory browser + installer.
  *
- * Submenu under the top-level "Agent Connector for WP" menu. It fetches a remote
- * directory of companion "ability pack" plugins (cached for 12h), matches it
- * against the plugins installed here, and lists the hits. Purely informational —
- * it never installs anything. A manual "Refresh now" button (admin-post + nonce)
- * busts the cache. Visibility is gated behind the same capability as the rest of
- * the plugin's admin area.
+ * Submenu under the top-level "Agent Connector for WP" menu. It asks the remote
+ * match endpoint which installed plugins have a companion "ability pack" available
+ * (cached for 12h), lists the hits, and offers one-click Install/Activate buttons
+ * for packs that aren't active yet. A manual "Refresh now" button (admin-post +
+ * nonce) busts the cache. All actions are gated behind the plugin's admin
+ * capability plus core's install_plugins/activate_plugins, with nonces.
  */
 final class DirectoryPage {
 
 	public const MENU_SLUG = 'agent-connector-for-wp-ability-packs';
 
-	private const REFRESH_ACTION = 'agent_connector_for_wp_refresh_directory';
+	private const REFRESH_ACTION  = 'agent_connector_for_wp_refresh_directory';
+	private const INSTALL_ACTION  = 'agent_connector_for_wp_install_pack';
+	private const ACTIVATE_ACTION = 'agent_connector_for_wp_activate_pack';
 
 	public function register(): void {
 		add_action( 'admin_menu', array( $this, 'register_menu' ) );
 		add_action( 'admin_post_' . self::REFRESH_ACTION, array( $this, 'handle_refresh' ) );
+		add_action( 'admin_post_' . self::INSTALL_ACTION, array( $this, 'handle_install' ) );
+		add_action( 'admin_post_' . self::ACTIVATE_ACTION, array( $this, 'handle_activate' ) );
 	}
 
 	/**
@@ -65,12 +69,10 @@ final class DirectoryPage {
 		<div class="wrap">
 			<h1><?php esc_html_e( 'Agent Connector for WP — Ability Packs', 'agent-connector-for-wp' ); ?></h1>
 
-			<?php if ( 'refreshed' === $notice ) : ?>
-				<div class="notice notice-success is-dismissible"><p><?php esc_html_e( 'Directory refreshed.', 'agent-connector-for-wp' ); ?></p></div>
-			<?php endif; ?>
+			<?php $this->render_notice( $notice ); ?>
 
 			<p style="max-width:50em;">
-				<?php esc_html_e( 'Some plugins on this site can be extended with a companion "ability pack" that registers AI abilities through Agent Connector. This page checks the published directory of ability packs against your installed plugins and lists the matches. It is informational only — nothing is installed automatically.', 'agent-connector-for-wp' ); ?>
+				<?php esc_html_e( 'Some plugins on this site can be extended with a companion "ability pack" that registers AI abilities through Agent Connector. This page checks the ability-pack directory against your installed plugins and lets you install any that are available. Installed packs are kept up to date automatically.', 'agent-connector-for-wp' ); ?>
 			</p>
 
 			<?php $this->render_toolbar( $result ); ?>
@@ -150,11 +152,14 @@ final class DirectoryPage {
 	 * @param array<string,mixed> $match A single PluginDirectory match.
 	 */
 	private function render_match_row( array $match ): void {
-		$entry      = (array) $match['entry'];
-		$pack_name  = (string) ( $entry['ability_pack_name'] ?? '' );
-		$desc       = (string) ( $entry['description'] ?? '' );
-		$source_url = (string) ( $entry['source_url'] ?? '' );
-		$version    = (string) ( $entry['version'] ?? '' );
+		$entry        = (array) $match['entry'];
+		$pack_name    = (string) ( $entry['ability_pack_name'] ?? '' );
+		$pack_slug    = (string) ( $entry['ability_pack_slug'] ?? '' );
+		$desc         = (string) ( $entry['description'] ?? '' );
+		$source_url   = (string) ( $entry['source_url'] ?? '' );
+		$version      = (string) ( $entry['version'] ?? '' );
+		$download_url = (string) ( $entry['download_url'] ?? '' );
+		$can_install  = current_user_can( 'install_plugins' ) && ! ( defined( 'DISALLOW_FILE_MODS' ) && DISALLOW_FILE_MODS );
 		?>
 		<tr>
 			<td>
@@ -184,8 +189,14 @@ final class DirectoryPage {
 					<span style="color:#1a7f37;font-weight:600;"><?php esc_html_e( 'Installed &amp; active', 'agent-connector-for-wp' ); ?></span>
 				<?php elseif ( $match['pack_installed'] ) : ?>
 					<span style="color:#996800;font-weight:600;"><?php esc_html_e( 'Installed, inactive', 'agent-connector-for-wp' ); ?></span>
+					<?php if ( $can_install && '' !== $pack_slug ) : ?>
+						<div style="margin-top:.4em;"><?php $this->render_action_form( self::ACTIVATE_ACTION, $pack_slug, __( 'Activate', 'agent-connector-for-wp' ), 'secondary' ); ?></div>
+					<?php endif; ?>
 				<?php else : ?>
 					<span style="color:#2271b1;font-weight:600;"><?php esc_html_e( 'Available to add', 'agent-connector-for-wp' ); ?></span>
+					<?php if ( $can_install && '' !== $pack_slug && '' !== $download_url ) : ?>
+						<div style="margin-top:.4em;"><?php $this->render_action_form( self::INSTALL_ACTION, $pack_slug, __( 'Install', 'agent-connector-for-wp' ), 'primary' ); ?></div>
+					<?php endif; ?>
 				<?php endif; ?>
 			</td>
 		</tr>
@@ -196,23 +207,200 @@ final class DirectoryPage {
 	 * admin-post: clear the cache and refetch, then redirect back.
 	 */
 	public function handle_refresh(): void {
-		if ( ! current_user_can( Config::CAP ) ) {
-			wp_die( esc_html__( 'You do not have permission to do this.', 'agent-connector-for-wp' ), '', array( 'response' => 403 ) );
-		}
-		check_admin_referer( self::REFRESH_ACTION );
+		$this->verify( self::REFRESH_ACTION );
 
 		PluginDirectory::clear_cache();
 		PluginDirectory::get( true );
 
+		$this->redirect( 'refreshed' );
+	}
+
+	/**
+	 * admin-post: download an ability pack's zip from the directory's trusted
+	 * download URL and install + activate it.
+	 */
+	public function handle_install(): void {
+		$this->verify( self::INSTALL_ACTION );
+
+		if ( ! current_user_can( 'install_plugins' ) || ( defined( 'DISALLOW_FILE_MODS' ) && DISALLOW_FILE_MODS ) ) {
+			$this->redirect( 'install_failed' );
+		}
+
+		$slug  = isset( $_POST['pack_slug'] ) ? sanitize_text_field( wp_unslash( $_POST['pack_slug'] ) ) : '';
+		$entry = $this->find_entry( $slug );
+		// Re-resolve the download URL server-side from the trusted directory — never
+		// trust a URL posted by the browser.
+		$url = null !== $entry ? (string) ( $entry['download_url'] ?? '' ) : '';
+		if ( '' === $url || ! self::is_allowed_download( $url ) ) {
+			$this->redirect( 'install_failed' );
+		}
+
+		require_once ABSPATH . 'wp-admin/includes/file.php';
+		require_once ABSPATH . 'wp-admin/includes/misc.php';
+		require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
+
+		// We can't show an FTP-credentials form from an admin-post handler, so bail
+		// cleanly when the filesystem isn't directly writable.
+		if ( 'direct' !== get_filesystem_method() ) {
+			$this->redirect( 'fs_unavailable' );
+		}
+
+		$upgrader = new \Plugin_Upgrader( new \Automatic_Upgrader_Skin() );
+		$result   = $upgrader->install( $url );
+
+		if ( is_wp_error( $result ) || true !== $result ) {
+			$this->redirect( 'install_failed' );
+		}
+
+		$plugin_file = (string) $upgrader->plugin_info();
+		if ( '' === $plugin_file ) {
+			$plugin_file = (string) ( PluginDirectory::installed_file_for_slug( $slug ) ?? '' );
+		}
+
+		if ( '' !== $plugin_file ) {
+			activate_plugin( $plugin_file, '', false, true );
+		}
+
+		PluginDirectory::clear_cache();
+		$this->redirect( 'installed' );
+	}
+
+	/**
+	 * admin-post: activate an already-installed ability pack.
+	 */
+	public function handle_activate(): void {
+		$this->verify( self::ACTIVATE_ACTION );
+
+		if ( ! current_user_can( 'activate_plugins' ) ) {
+			$this->redirect( 'install_failed' );
+		}
+
+		$slug = isset( $_POST['pack_slug'] ) ? sanitize_text_field( wp_unslash( $_POST['pack_slug'] ) ) : '';
+		$file = PluginDirectory::installed_file_for_slug( $slug );
+		if ( null === $file ) {
+			$this->redirect( 'install_failed' );
+		}
+
+		require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		$result = activate_plugin( $file, '', false, true );
+
+		PluginDirectory::clear_cache();
+		$this->redirect( is_wp_error( $result ) ? 'install_failed' : 'activated' );
+	}
+
+	/**
+	 * Capability + nonce gate shared by every admin-post handler here.
+	 */
+	private function verify( string $action ): void {
+		if ( ! current_user_can( Config::CAP ) ) {
+			wp_die( esc_html__( 'You do not have permission to do this.', 'agent-connector-for-wp' ), '', array( 'response' => 403 ) );
+		}
+		check_admin_referer( $action );
+	}
+
+	/**
+	 * Redirect back to this screen with a notice key, then stop.
+	 */
+	private function redirect( string $notice ): void {
 		wp_safe_redirect(
 			add_query_arg(
 				array(
 					'page'        => self::MENU_SLUG,
-					'acfw_notice' => 'refreshed',
+					'acfw_notice' => $notice,
 				),
 				admin_url( 'admin.php' )
 			)
 		);
 		exit;
+	}
+
+	/**
+	 * Find a directory entry by its ability-pack slug (cache-aware).
+	 *
+	 * @return array<string,string>|null
+	 */
+	private function find_entry( string $slug ): ?array {
+		if ( '' === $slug ) {
+			return null;
+		}
+		foreach ( PluginDirectory::get()['entries'] as $entry ) {
+			if ( isset( $entry['ability_pack_slug'] ) && $entry['ability_pack_slug'] === $slug ) {
+				return $entry;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Only allow downloading pack zips over https from an allowlisted host
+	 * (the GitHub release hosts by default). Filterable.
+	 */
+	private static function is_allowed_download( string $url ): bool {
+		$parts = wp_parse_url( $url );
+		if ( empty( $parts['scheme'] ) || 'https' !== strtolower( (string) $parts['scheme'] ) || empty( $parts['host'] ) ) {
+			return false;
+		}
+		$host = strtolower( (string) $parts['host'] );
+
+		/**
+		 * Filters the hosts an ability-pack zip may be downloaded from.
+		 *
+		 * @param array<int,string> $hosts Allowlisted hostnames (and their subdomains).
+		 */
+		$allowed = (array) apply_filters(
+			'agent_connector_for_wp_pack_download_hosts',
+			array( 'github.com', 'objects.githubusercontent.com', 'codeload.github.com' )
+		);
+
+		foreach ( $allowed as $h ) {
+			$h = strtolower( (string) $h );
+			if ( '' === $h ) {
+				continue;
+			}
+			if ( $host === $h || substr( $host, -strlen( '.' . $h ) ) === '.' . $h ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Render a small POST form (action button) for install/activate. Posts only
+	 * the pack slug + nonce; the handler re-resolves everything else server-side.
+	 */
+	private function render_action_form( string $action, string $slug, string $label, string $type ): void {
+		?>
+		<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" style="display:inline;">
+			<input type="hidden" name="action" value="<?php echo esc_attr( $action ); ?>" />
+			<input type="hidden" name="pack_slug" value="<?php echo esc_attr( $slug ); ?>" />
+			<?php wp_nonce_field( $action ); ?>
+			<?php submit_button( $label, $type, 'submit', false ); ?>
+		</form>
+		<?php
+	}
+
+	/**
+	 * Render the result notice for a given notice key (post-redirect-get).
+	 */
+	private function render_notice( string $notice ): void {
+		$map = array(
+			'refreshed'      => array( 'success', __( 'Directory refreshed.', 'agent-connector-for-wp' ) ),
+			'installed'      => array( 'success', __( 'Ability pack installed and activated.', 'agent-connector-for-wp' ) ),
+			'activated'      => array( 'success', __( 'Ability pack activated.', 'agent-connector-for-wp' ) ),
+			'install_failed' => array( 'error', __( 'Could not install the ability pack. Check that it is available and that this site can install plugins.', 'agent-connector-for-wp' ) ),
+			'fs_unavailable' => array( 'error', __( 'This site cannot install plugins directly (no direct filesystem access). Install the pack zip manually instead.', 'agent-connector-for-wp' ) ),
+		);
+		if ( ! isset( $map[ $notice ] ) ) {
+			return;
+		}
+		list( $kind, $message ) = $map[ $notice ];
+		printf(
+			'<div class="notice notice-%1$s is-dismissible"><p>%2$s</p></div>',
+			esc_attr( $kind ),
+			esc_html( $message )
+		);
 	}
 }

--- a/plugin/src/Services/PackUpdater.php
+++ b/plugin/src/Services/PackUpdater.php
@@ -1,0 +1,168 @@
+<?php
+/**
+ * Host-managed updates for installed ability packs.
+ *
+ * @package AgentConnectorForWp
+ */
+
+declare( strict_types=1 );
+
+namespace AgentConnectorForWp\Services;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Keeps installed "ability pack" companion plugins updatable straight from GitHub,
+ * without each pack having to bundle its own update checker.
+ *
+ * It detects installed packs by their marker header, reads the latest version +
+ * download URL for each from the same directory the Ability Packs screen uses
+ * (PluginDirectory — one cached request, manifest-backed, scales to many packs),
+ * and injects the results into WordPress's `update_plugins` site transient so the
+ * normal Plugins-screen update flow (and auto-updates) handle the rest.
+ *
+ * Nothing here touches the plugin-update-checker library — that stays dedicated to
+ * the main agent-connector-for-wp plugin.
+ */
+final class PackUpdater {
+
+	public function register(): void {
+		add_filter( 'extra_plugin_headers', array( $this, 'declare_headers' ) );
+		add_filter( 'pre_set_site_transient_update_plugins', array( $this, 'inject_updates' ) );
+	}
+
+	/**
+	 * Surface the ability-pack marker headers through get_plugins()/get_plugin_data().
+	 *
+	 * Core only parses a fixed header set unless extended here. `Agent Connector`
+	 * carries the marker value ("Ability Pack"); `Agent Connector Target` carries the
+	 * host plugin file the pack extends.
+	 *
+	 * @param array<string,string> $headers Extra headers to parse.
+	 *
+	 * @return array<string,string>
+	 */
+	public function declare_headers( $headers ) {
+		$headers = (array) $headers;
+		$headers['AgentConnectorAbilityPack'] = 'Agent Connector';
+		$headers['AgentConnectorTarget']      = 'Agent Connector Target';
+
+		return $headers;
+	}
+
+	/**
+	 * Inject available pack updates into the update_plugins transient.
+	 *
+	 * @param mixed $transient The update_plugins site transient (object) or empty.
+	 *
+	 * @return mixed
+	 */
+	public function inject_updates( $transient ) {
+		if ( ! is_object( $transient ) ) {
+			return $transient;
+		}
+
+		$packs = $this->installed_packs();
+		if ( empty( $packs ) ) {
+			return $transient;
+		}
+
+		$by_slug = $this->entries_by_slug();
+		if ( empty( $by_slug ) ) {
+			return $transient;
+		}
+
+		if ( ! isset( $transient->response ) || ! is_array( $transient->response ) ) {
+			$transient->response = array();
+		}
+		if ( ! isset( $transient->no_update ) || ! is_array( $transient->no_update ) ) {
+			$transient->no_update = array();
+		}
+
+		foreach ( $packs as $file => $installed_version ) {
+			$slug = $this->folder_slug( $file );
+			if ( ! isset( $by_slug[ $slug ] ) ) {
+				continue;
+			}
+
+			$entry   = $by_slug[ $slug ];
+			$latest  = (string) ( $entry['version'] ?? '' );
+			$package = (string) ( $entry['download_url'] ?? '' );
+			if ( '' === $latest ) {
+				continue;
+			}
+
+			$info = (object) array(
+				'slug'        => $slug,
+				'plugin'      => $file,
+				'new_version' => $latest,
+				'url'         => (string) ( $entry['source_url'] ?? '' ),
+				'package'     => $package,
+				'icons'       => array(),
+				'banners'     => array(),
+			);
+
+			if ( '' !== $package && version_compare( $installed_version, $latest, '<' ) ) {
+				$transient->response[ $file ] = $info;
+				unset( $transient->no_update[ $file ] );
+			} else {
+				// Up to date — list under no_update so core treats it as managed.
+				$info->new_version             = $installed_version;
+				$transient->no_update[ $file ] = $info;
+			}
+		}
+
+		return $transient;
+	}
+
+	/**
+	 * Installed ability packs as plugin_file => installed version.
+	 *
+	 * @return array<string,string>
+	 */
+	private function installed_packs(): array {
+		if ( ! function_exists( 'get_plugins' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
+
+		$out = array();
+		foreach ( (array) get_plugins() as $file => $data ) {
+			$marker = isset( $data['AgentConnectorAbilityPack'] ) ? trim( (string) $data['AgentConnectorAbilityPack'] ) : '';
+			if ( '' === $marker ) {
+				continue;
+			}
+			$out[ $file ] = isset( $data['Version'] ) ? (string) $data['Version'] : '0';
+		}
+
+		return $out;
+	}
+
+	/**
+	 * Directory entries keyed by ability_pack_slug (cache-aware, manifest-backed).
+	 *
+	 * @return array<string,array<string,string>>
+	 */
+	private function entries_by_slug(): array {
+		$result  = PluginDirectory::get();
+		$by_slug = array();
+		foreach ( (array) $result['entries'] as $entry ) {
+			$slug = isset( $entry['ability_pack_slug'] ) ? (string) $entry['ability_pack_slug'] : '';
+			if ( '' !== $slug ) {
+				$by_slug[ $slug ] = $entry;
+			}
+		}
+
+		return $by_slug;
+	}
+
+	/**
+	 * "unofficial-abilities-for-x/unofficial-abilities-for-x.php" → folder slug.
+	 */
+	private function folder_slug( string $file ): string {
+		if ( false !== strpos( $file, '/' ) ) {
+			return dirname( $file );
+		}
+
+		return preg_replace( '/\.php$/', '', $file ) ?? $file;
+	}
+}

--- a/plugin/src/Services/PluginDirectory.php
+++ b/plugin/src/Services/PluginDirectory.php
@@ -27,14 +27,15 @@ defined( 'ABSPATH' ) || exit;
 final class PluginDirectory {
 
 	/**
-	 * Default remote directory URL.
+	 * Default ability-pack match endpoint (the agent-ready-plugins-tracker app).
 	 *
-	 * PLACEHOLDER — there is no live endpoint yet. Point this (or the
-	 * `agent_connector_for_wp_directory_url` filter) at the real published
-	 * directory.json before relying on it. A 404 here is handled gracefully:
-	 * the UI shows a clean "directory unavailable" state, never a fatal.
+	 * This site POSTs its installed plugins here and gets back the ability packs
+	 * that target any of them (the tracker reads them from the GitHub `pack-index`
+	 * manifest). Override with the `agent_connector_for_wp_directory_url` filter.
+	 * A failure is handled gracefully: the UI shows a clean "directory unavailable"
+	 * state and falls back to the last cached copy, never a fatal.
 	 */
-	public const DEFAULT_DIRECTORY_URL = 'https://raw.githubusercontent.com/soflyy/agent-connector-for-wp-directory/main/directory.json';
+	public const DEFAULT_DIRECTORY_URL = 'https://agent-ready-plugins-tracker-git-master-future-layer.vercel.app/api/ability-packs/match';
 
 	/**
 	 * Transient holding the last successfully fetched + normalized directory.
@@ -69,14 +70,19 @@ final class PluginDirectory {
 	}
 
 	/**
-	 * Return the cached directory, or null when nothing has been cached yet.
+	 * Return the cached payload, or null when nothing usable has been cached yet.
 	 *
-	 * @return array<int,array<string,string>>|null
+	 * The payload wraps the entries with the installed-plugins fingerprint that
+	 * was current when it was stored, so a changed plugin set can invalidate it.
+	 *
+	 * @return array{fp:string,entries:array<int,array<string,string>>}|null
 	 */
 	public static function cached(): ?array {
 		$cached = get_transient( self::CACHE_KEY );
 
-		return is_array( $cached ) ? $cached : null;
+		return ( is_array( $cached ) && isset( $cached['entries'] ) && is_array( $cached['entries'] ) )
+			? $cached
+			: null;
 	}
 
 	/**
@@ -94,12 +100,15 @@ final class PluginDirectory {
 	 */
 	public static function get( bool $force = false ): array {
 		$url = self::directory_url();
+		$fp  = self::installed_fingerprint();
 
 		if ( ! $force ) {
 			$cached = self::cached();
-			if ( null !== $cached ) {
+			// Only serve the cache when it was built for the same installed-plugin
+			// set; otherwise a newly installed plugin would stay hidden for 12h.
+			if ( null !== $cached && isset( $cached['fp'] ) && $cached['fp'] === $fp ) {
 				return array(
-					'entries' => $cached,
+					'entries' => $cached['entries'],
 					'stale'   => false,
 					'error'   => '',
 					'url'     => $url,
@@ -110,7 +119,7 @@ final class PluginDirectory {
 		$fetched = self::fetch( $url );
 
 		if ( null !== $fetched ) {
-			set_transient( self::CACHE_KEY, $fetched, self::CACHE_TTL );
+			set_transient( self::CACHE_KEY, array( 'fp' => $fp, 'entries' => $fetched ), self::CACHE_TTL );
 
 			return array(
 				'entries' => $fetched,
@@ -120,11 +129,12 @@ final class PluginDirectory {
 			);
 		}
 
-		// Network/parse failed — fall back to any (possibly stale) cached copy.
+		// Network/parse failed — fall back to any (possibly stale) cached copy,
+		// even if the installed set has since changed: stale-but-real beats empty.
 		$cached = self::cached();
 		if ( null !== $cached ) {
 			return array(
-				'entries' => $cached,
+				'entries' => $cached['entries'],
 				'stale'   => true,
 				'error'   => __( 'Could not refresh the directory; showing the last cached copy.', 'agent-connector-for-wp' ),
 				'url'     => $url,
@@ -154,16 +164,25 @@ final class PluginDirectory {
 	 * @return array<int,array<string,string>>|null Normalized entries, or null on any failure.
 	 */
 	private static function fetch( string $url ): ?array {
-		if ( '' === $url || ! function_exists( 'wp_remote_get' ) ) {
+		if ( '' === $url || ! function_exists( 'wp_remote_post' ) ) {
 			return null;
 		}
 
-		$response = wp_remote_get(
+		$payload = array(
+			'site_url' => home_url(),
+			'plugins'  => self::installed_plugin_slugs(),
+		);
+
+		$response = wp_remote_post(
 			$url,
 			array(
 				'timeout'    => self::HTTP_TIMEOUT,
 				'user-agent' => 'AgentConnectorForWp/' . ( defined( 'AGENT_CONNECTOR_FOR_WP_VERSION' ) ? AGENT_CONNECTOR_FOR_WP_VERSION : 'dev' ),
-				'headers'    => array( 'Accept' => 'application/json' ),
+				'headers'    => array(
+					'Accept'       => 'application/json',
+					'Content-Type' => 'application/json',
+				),
+				'body'       => (string) wp_json_encode( $payload ),
 			)
 		);
 
@@ -236,20 +255,20 @@ final class PluginDirectory {
 			return null;
 		}
 
-		$target = isset( $item['target_plugin'] ) && is_string( $item['target_plugin'] )
-			? trim( $item['target_plugin'] )
-			: '';
-		$pack_name = isset( $item['ability_pack_name'] ) && is_string( $item['ability_pack_name'] )
-			? trim( $item['ability_pack_name'] )
-			: '';
+		$str = static function ( $value ): string {
+			return is_string( $value ) ? trim( $value ) : '';
+		};
+
+		$target = $str( $item['target_plugin'] ?? '' );
+		// Prefer ability_pack_name; fall back to the generic `name` field.
+		$pack_name = $str( $item['ability_pack_name'] ?? '' );
+		if ( '' === $pack_name ) {
+			$pack_name = $str( $item['name'] ?? '' );
+		}
 
 		if ( '' === $target || '' === $pack_name ) {
 			return null;
 		}
-
-		$str = static function ( $value ): string {
-			return is_string( $value ) ? trim( $value ) : '';
-		};
 
 		return array(
 			'target_plugin'      => $target,
@@ -259,6 +278,7 @@ final class PluginDirectory {
 			'source_url'        => $str( $item['source_url'] ?? '' ),
 			'description'       => $str( $item['description'] ?? '' ),
 			'version'           => $str( $item['version'] ?? '' ),
+			'download_url'      => $str( $item['download_url'] ?? '' ),
 		);
 	}
 
@@ -334,6 +354,44 @@ final class PluginDirectory {
 		}
 
 		return (array) get_plugins();
+	}
+
+	/**
+	 * The installed plugins as a compact list for the match request body.
+	 *
+	 * @return array<int,array{slug:string,file:string,active:bool}>
+	 */
+	private static function installed_plugin_slugs(): array {
+		$out = array();
+		foreach ( array_keys( self::installed_plugins() ) as $file ) {
+			$out[] = array(
+				'slug'   => self::folder_slug( $file ),
+				'file'   => $file,
+				'active' => self::is_active( $file ),
+			);
+		}
+
+		return $out;
+	}
+
+	/**
+	 * A fingerprint of the installed-plugin set, used to invalidate the cache when
+	 * plugins are added/removed (the match response depends on what's installed).
+	 */
+	private static function installed_fingerprint(): string {
+		$files = array_keys( self::installed_plugins() );
+		sort( $files );
+
+		return md5( implode( '|', $files ) );
+	}
+
+	/**
+	 * Resolve an ability-pack (or target) slug to its installed plugin file, or
+	 * null when it isn't installed. Public so the admin install/activate flow and
+	 * the pack updater can share the same tolerant matching.
+	 */
+	public static function installed_file_for_slug( string $slug ): ?string {
+		return self::find_installed_key( $slug, self::installed_plugins() );
 	}
 
 	/**


### PR DESCRIPTION
Fourth and final PR. Makes the **Ability Packs** admin screen actually install packs and keeps installed packs updated. **This is the only PR touching `plugin/**`, so merging it cuts a plugin release.**

## WordPress changes
**`PluginDirectory`** — POST the site's installed plugins to the tracker's `/api/ability-packs/match` endpoint (was: GET a static `directory.json`). Adds `download_url` to entries; fingerprints the 12h cache by the installed-plugin set so new installs aren't hidden; adds `installed_file_for_slug()` / `installed_plugin_slugs()` helpers.

**`DirectoryPage`** — one-click **Install** (download zip → install → activate) and **Activate** buttons. Hardening:
- `Config::CAP` **and** core `install_plugins`/`activate_plugins`; nonce on every action; respects `DISALLOW_FILE_MODS`.
- Download URL **re-resolved server-side** from the trusted directory (never from the POST body); restricted to `https` on an allowlisted host (filter `agent_connector_for_wp_pack_download_hosts`, GitHub by default).
- Quiet `Automatic_Upgrader_Skin`; graceful when the filesystem isn't directly writable.

**`PackUpdater`** (new) — detects installed packs via the `Agent Connector` marker header (surfaced through `extra_plugin_headers`) and injects updates into the `update_plugins` transient from the manifest-backed cache (no per-request network), so core's normal update UI handles pack updates. plugin-update-checker stays dedicated to the main plugin.

**Docs** — `directory-schema.md` (POST request shape, `download_url`, install/update behavior), `directory.json` sample, `registering-abilities.md` naming.

## ⚠️ Action required before this works end-to-end
1. **Make the tracker API public.** The deployment currently returns **HTTP 401** (Vercel Deployment Protection). The plugin calls it server-to-server with no SSO, so it must be publicly reachable — disable Deployment Protection for the project (or for `/api/ability-packs`), or expose a public production domain.
2. The default endpoint is baked as `https://agent-ready-plugins-tracker-git-master-future-layer.vercel.app/api/ability-packs/match`. Override anytime via the `agent_connector_for_wp_directory_url` filter (e.g. to a custom domain).
3. Needs #12–#14 merged, and PR2's release workflow run once (`pack=all`) so `pack-index/index.json` exists with real `download_url`s.

## Verification
All changed PHP lints clean; the live sandbox (plugin is symlinked) loads with no fatals (`wp plugin list` OK). Full click-through Install/update verification is gated on the manifest existing + the endpoint being public (steps above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)