### PR TITLE
feat(tracker): return per-plugin AI status from the match endpoint

### DIFF
--- a/agent-ready-plugins-tracker/app/api/ability-packs/match/route.ts
+++ b/agent-ready-plugins-tracker/app/api/ability-packs/match/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { getStatusesForSlugs } from "@/lib/db";
 
 // Public, server-to-server endpoint hit by the Agent Connector for WP plugin.
 // A site POSTs the plugins it has installed; we return the ability packs that
@@ -92,5 +93,29 @@ export async function POST(req: NextRequest) {
     return wanted.has(folderSlug(target)) || wanted.has(target);
   });
 
-  return NextResponse.json({ entries });
+  // Enrich with per-plugin AI status (official built-in / third-party unofficial
+  // extensions) from the directory DB, so the site can show the full picture —
+  // not just our own packs. Best-effort: an unconfigured/erroring DB yields [].
+  let statuses: object[] = [];
+  try {
+    const map = await getStatusesForSlugs([...wanted]);
+    statuses = Object.entries(map).map(([slug, s]) => ({
+      slug,
+      level: s.level,
+      official_since: s.officialSince ?? null,
+      official_docs_url: s.officialDocsUrl ?? null,
+      abilities_count: s.abilitiesCount ?? null,
+      unofficial_plugins: (s.unofficialPlugins ?? []).map((u) => ({
+        name: u.name,
+        plugin_url: u.pluginUrl,
+        description: u.description,
+        author: u.author,
+        author_url: u.authorUrl ?? null,
+      })),
+    }));
+  } catch {
+    statuses = [];
+  }
+
+  return NextResponse.json({ entries, statuses });
 }

--- a/agent-ready-plugins-tracker/lib/db.ts
+++ b/agent-ready-plugins-tracker/lib/db.ts
@@ -66,6 +66,21 @@ export async function getPluginWithStatus(slug: string): Promise<PluginWithStatu
   };
 }
 
+/**
+ * AI status for a set of plugin slugs, keyed by slug. Used by the ability-pack
+ * match endpoint to tell a site which of its plugins have official / third-party
+ * AI abilities. Missing slugs are simply absent from the map.
+ */
+export async function getStatusesForSlugs(slugs: string[]): Promise<Record<string, AIStatus>> {
+  const supabase = getClient();
+  if (!supabase || slugs.length === 0) return {};
+  const { data } = await supabase.from("ai_statuses").select("*").in("slug", slugs);
+  if (!data) return {};
+  const out: Record<string, AIStatus> = {};
+  for (const row of data) out[row.slug as string] = rowToStatus(row);
+  return out;
+}
+
 // ---- AI Status ----
 
 export async function setAIStatus(slug: string, status: AIStatus): Promise<void> {


### PR DESCRIPTION
Part 1 of the Abilities-page redesign. Lets the WordPress plugin show the *full* AI-ability picture per plugin (official built-in / third-party unofficial / ours), using the directory data the tracker already has.

- `lib/db.ts`: `getStatusesForSlugs(slugs)` — one `ai_statuses … .in('slug', slugs)` query → slug→status map.
- `app/api/ability-packs/match`: now returns `{ entries, statuses }`. `entries` (our packs) unchanged; `statuses[]` = `{ slug, level, official_since, official_docs_url, abilities_count, unofficial_plugins[] }` for the requested slugs. Best-effort — unconfigured/erroring DB → `statuses: []`.

Backward compatible: existing consumers reading `entries` are unaffected. Endpoint stays public (directory data).

Verified: `npx tsc --noEmit` clean. End-to-end curl check after deploy (woocommerce→official, gravityforms→unofficial third-party).

Pairs with the plugin PR (Abilities page).

🤖 Generated with [Claude Code](https://claude.com/claude-code)