### PR TITLE
feat: Abilities page — tabs, ecosystem availability, pack lifecycle, registered abilities

### DIFF
--- a/plugin/docs/directory-schema.md
+++ b/plugin/docs/directory-schema.md
@@ -32,15 +32,30 @@ the data from the GitHub `pack-index` manifest the release CI generates.
 
 ## Response shape
 
-A JSON **object** with an `entries` array (a bare array is also accepted):
+A JSON **object** with an `entries` array (our installable packs) and an optional
+`statuses` array (per-plugin ecosystem AI-support info). A bare array is also
+accepted and treated as `entries`.
 
 ```json
 {
-  "entries": [ /* entry objects */ ]
+  "entries":  [ /* entry objects (our generated packs) */ ],
+  "statuses": [ /* status objects (official / third-party support per plugin) */ ]
 }
 ```
 
-The client normalizes both to the same internal list.
+## Status object (optional, per plugin)
+
+Drives the "Available AI abilities" column — informational only (nothing here is
+installed by the plugin). Keyed by plugin slug; entries without a `slug` are dropped.
+
+| Field                | Type   | Notes |
+| -------------------- | ------ | ----- |
+| `slug`               | string | The plugin's folder slug (join key). **Required** within a status object. |
+| `level`              | string | `official` \| `unofficial` \| `coming_soon` \| `none`. |
+| `official_since`     | string | Plugin version that added official AI abilities (when `official`). |
+| `official_docs_url`  | string | Link to official docs / roadmap. |
+| `abilities_count`    | int    | Number of official abilities, if known. |
+| `unofficial_plugins` | array  | Third-party extensions: `{ name, plugin_url, description, author, author_url }`. Rendered as informational links. |
 
 ## Entry object
 

--- a/plugin/src/Admin/DirectoryPage.php
+++ b/plugin/src/Admin/DirectoryPage.php
@@ -29,25 +29,27 @@ final class DirectoryPage {
 
 	public const MENU_SLUG = 'agent-connector-for-wp-ability-packs';
 
-	private const REFRESH_ACTION  = 'agent_connector_for_wp_refresh_directory';
-	private const INSTALL_ACTION  = 'agent_connector_for_wp_install_pack';
-	private const ACTIVATE_ACTION = 'agent_connector_for_wp_activate_pack';
+	private const REFRESH_ACTION    = 'agent_connector_for_wp_refresh_directory';
+	private const INSTALL_ACTION    = 'agent_connector_for_wp_install_pack';
+	private const ACTIVATE_ACTION   = 'agent_connector_for_wp_activate_pack';
+	private const DEACTIVATE_ACTION = 'agent_connector_for_wp_deactivate_pack';
 
 	public function register(): void {
 		add_action( 'admin_menu', array( $this, 'register_menu' ) );
 		add_action( 'admin_post_' . self::REFRESH_ACTION, array( $this, 'handle_refresh' ) );
 		add_action( 'admin_post_' . self::INSTALL_ACTION, array( $this, 'handle_install' ) );
 		add_action( 'admin_post_' . self::ACTIVATE_ACTION, array( $this, 'handle_activate' ) );
+		add_action( 'admin_post_' . self::DEACTIVATE_ACTION, array( $this, 'handle_deactivate' ) );
 	}
 
 	/**
-	 * Add the "Ability Packs" submenu beneath the plugin's top-level menu.
+	 * Add the "Abilities" submenu beneath the plugin's top-level menu.
 	 */
 	public function register_menu(): void {
 		add_submenu_page(
 			ConnectionPage::MENU_SLUG,
-			__( 'Agent Connector — Ability Packs', 'agent-connector-for-wp' ),
-			__( 'Ability Packs', 'agent-connector-for-wp' ),
+			__( 'Agent Connector — Abilities', 'agent-connector-for-wp' ),
+			__( 'Abilities', 'agent-connector-for-wp' ),
 			Config::CAP,
 			self::MENU_SLUG,
 			array( $this, 'render_page' )
@@ -55,36 +57,68 @@ final class DirectoryPage {
 	}
 
 	/**
-	 * Render the Ability Packs screen.
+	 * Render the Abilities screen — tabbed: Ability Packs + Registered Abilities.
 	 */
 	public function render_page(): void {
 		if ( ! current_user_can( Config::CAP ) ) {
 			return;
 		}
 
-		$result  = PluginDirectory::installed_overview();
-		$rows    = $result['rows'];
-		$notice  = isset( $_GET['acfw_notice'] ) ? sanitize_key( wp_unslash( $_GET['acfw_notice'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$tabs   = array(
+			'packs'     => __( 'Ability Packs', 'agent-connector-for-wp' ),
+			'abilities' => __( 'Registered Abilities', 'agent-connector-for-wp' ),
+		);
+		$tab    = isset( $_GET['tab'] ) ? sanitize_key( wp_unslash( $_GET['tab'] ) ) : 'packs'; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$notice = isset( $_GET['acfw_notice'] ) ? sanitize_key( wp_unslash( $_GET['acfw_notice'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( ! isset( $tabs[ $tab ] ) ) {
+			$tab = 'packs';
+		}
 		?>
 		<div class="wrap">
-			<h1><?php esc_html_e( 'Agent Connector for WP — Ability Packs', 'agent-connector-for-wp' ); ?></h1>
+			<h1><?php esc_html_e( 'Agent Connector for WP — Abilities', 'agent-connector-for-wp' ); ?></h1>
 
 			<?php $this->render_notice( $notice ); ?>
 
-			<p style="max-width:50em;">
-				<?php esc_html_e( 'Plugins on this site can be extended with a companion "ability pack" that registers AI abilities through Agent Connector. This lists your installed plugins and, where one is available, lets you install it in one click. Installed packs are kept up to date automatically.', 'agent-connector-for-wp' ); ?>
-			</p>
+			<h2 class="nav-tab-wrapper">
+				<?php foreach ( $tabs as $key => $label ) : ?>
+					<a
+						href="<?php echo esc_url( add_query_arg( array( 'page' => self::MENU_SLUG, 'tab' => $key ), admin_url( 'admin.php' ) ) ); ?>"
+						class="nav-tab <?php echo esc_attr( $tab === $key ? 'nav-tab-active' : '' ); ?>"
+					><?php echo esc_html( $label ); ?></a>
+				<?php endforeach; ?>
+			</h2>
 
-			<?php $this->render_toolbar( $result ); ?>
-
-			<?php if ( '' !== $result['error'] ) : ?>
-				<div class="notice notice-warning inline" style="max-width:50em;">
-					<p><?php echo esc_html( $result['error'] ); ?></p>
-				</div>
-			<?php endif; ?>
-
-			<?php $this->render_table( $rows ); ?>
+			<?php
+			if ( 'abilities' === $tab ) {
+				$this->render_abilities_tab();
+			} else {
+				$this->render_packs_tab();
+			}
+			?>
 		</div>
+		<?php
+	}
+
+	/**
+	 * The "Ability Packs" tab: active plugins, the AI abilities available for each
+	 * (official / third-party / ours), and one-click install of our packs.
+	 */
+	private function render_packs_tab(): void {
+		$result = PluginDirectory::installed_overview();
+		?>
+		<p style="max-width:52em;">
+			<?php esc_html_e( 'Your active plugins and the AI abilities available for each — official (built into the plugin), third-party extensions, and the optional unofficial ability pack we generate. Installing our pack is always optional.', 'agent-connector-for-wp' ); ?>
+		</p>
+
+		<?php $this->render_toolbar( $result ); ?>
+
+		<?php if ( '' !== $result['error'] ) : ?>
+			<div class="notice notice-warning inline" style="max-width:50em;">
+				<p><?php echo esc_html( $result['error'] ); ?></p>
+			</div>
+		<?php endif; ?>
+
+		<?php $this->render_table( $result['rows'] ); ?>
 		<?php
 	}
 
@@ -125,12 +159,12 @@ final class DirectoryPage {
 			return;
 		}
 		?>
-		<table class="widefat striped" style="max-width:64em;margin-top:1em;">
+		<table class="widefat striped" style="max-width:72em;margin-top:1em;">
 			<thead>
 				<tr>
-					<th scope="col"><?php esc_html_e( 'Installed plugin', 'agent-connector-for-wp' ); ?></th>
-					<th scope="col"><?php esc_html_e( 'Ability pack', 'agent-connector-for-wp' ); ?></th>
-					<th scope="col"><?php esc_html_e( 'Status', 'agent-connector-for-wp' ); ?></th>
+					<th scope="col"><?php esc_html_e( 'Active plugin', 'agent-connector-for-wp' ); ?></th>
+					<th scope="col"><?php esc_html_e( 'Available AI abilities', 'agent-connector-for-wp' ); ?></th>
+					<th scope="col"><?php esc_html_e( 'Unofficial ability pack', 'agent-connector-for-wp' ); ?></th>
 				</tr>
 			</thead>
 			<tbody>
@@ -143,38 +177,107 @@ final class DirectoryPage {
 	}
 
 	/**
-	 * Render one installed-plugin row — with its ability pack + actions when one
-	 * is available, or a "no pack" indicator otherwise.
+	 * Render one active-plugin row: the plugin, the AI abilities available for it
+	 * (official / third-party), and our optional ability pack with its actions.
 	 *
 	 * @param array<string,mixed> $row A single PluginDirectory overview row.
 	 */
 	private function render_row( array $row ): void {
-		$has_pack = ! empty( $row['has_pack'] );
 		?>
 		<tr>
 			<td>
 				<strong><?php echo esc_html( (string) $row['plugin_name'] ); ?></strong><br />
 				<code style="font-size:11px;"><?php echo esc_html( (string) $row['plugin_file'] ); ?></code>
-				<?php if ( empty( $row['plugin_active'] ) ) : ?>
-					<br /><span class="description"><?php esc_html_e( '(installed, not active)', 'agent-connector-for-wp' ); ?></span>
-				<?php endif; ?>
 			</td>
-			<?php if ( ! $has_pack ) : ?>
-				<td><span class="description">—</span></td>
-				<td><span class="description"><?php esc_html_e( 'No ability pack available yet', 'agent-connector-for-wp' ); ?></span></td>
-			<?php else : ?>
-				<?php $this->render_pack_cells( $row ); ?>
-			<?php endif; ?>
+			<td><?php $this->render_availability_cell( (array) ( $row['ai_status'] ?? array() ) ); ?></td>
+			<td><?php $this->render_pack_cell( $row ); ?></td>
 		</tr>
 		<?php
 	}
 
 	/**
-	 * Render the "Ability pack" + "Status" cells for a row that has a pack.
+	 * The "Available AI abilities" cell — official built-in support and/or
+	 * third-party unofficial extensions, from the directory. Informational only.
+	 *
+	 * @param array<string,mixed> $ai Normalized ai_status for the plugin.
+	 */
+	private function render_availability_cell( array $ai ): void {
+		$level      = (string) ( $ai['level'] ?? '' );
+		$docs       = (string) ( $ai['official_docs_url'] ?? '' );
+		$since      = (string) ( $ai['official_since'] ?? '' );
+		$count      = (int) ( $ai['abilities_count'] ?? 0 );
+		$unofficial = isset( $ai['unofficial_plugins'] ) && is_array( $ai['unofficial_plugins'] ) ? $ai['unofficial_plugins'] : array();
+
+		$shown = false;
+
+		if ( 'official' === $level ) {
+			$shown = true;
+			echo '<span style="color:#1a7f37;font-weight:600;">' . esc_html__( 'Official — built in', 'agent-connector-for-wp' ) . '</span>';
+			$bits = array();
+			if ( '' !== $since ) {
+				/* translators: %s: plugin version. */
+				$bits[] = sprintf( esc_html__( 'since v%s', 'agent-connector-for-wp' ), esc_html( $since ) );
+			}
+			if ( $count > 0 ) {
+				/* translators: %d: number of abilities. */
+				$bits[] = esc_html( sprintf( _n( '%d ability', '%d abilities', $count, 'agent-connector-for-wp' ), $count ) );
+			}
+			if ( $bits ) {
+				echo ' <span class="description">(' . implode( ', ', $bits ) . ')</span>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			}
+			if ( '' !== $docs ) {
+				echo '<br /><a href="' . esc_url( $docs ) . '" target="_blank" rel="noopener noreferrer">' . esc_html__( 'Documentation', 'agent-connector-for-wp' ) . '</a>';
+			}
+		} elseif ( 'coming_soon' === $level ) {
+			$shown = true;
+			echo '<span style="color:#996800;font-weight:600;">' . esc_html__( 'Official support coming soon', 'agent-connector-for-wp' ) . '</span>';
+			if ( '' !== $docs ) {
+				echo ' — <a href="' . esc_url( $docs ) . '" target="_blank" rel="noopener noreferrer">' . esc_html__( 'roadmap', 'agent-connector-for-wp' ) . '</a>';
+			}
+		}
+
+		if ( ! empty( $unofficial ) ) {
+			$shown = true;
+			echo '<p class="description" style="margin:.4em 0 0;"><strong>' . esc_html__( 'Third-party extensions:', 'agent-connector-for-wp' ) . '</strong></p><ul style="margin:.2em 0 0 1.2em;list-style:disc;">';
+			foreach ( $unofficial as $u ) {
+				$name   = (string) ( $u['name'] ?? '' );
+				$purl   = (string) ( $u['plugin_url'] ?? '' );
+				$author = (string) ( $u['author'] ?? '' );
+				if ( '' === $name ) {
+					continue;
+				}
+				echo '<li>';
+				if ( '' !== $purl ) {
+					echo '<a href="' . esc_url( $purl ) . '" target="_blank" rel="noopener noreferrer">' . esc_html( $name ) . '</a>';
+				} else {
+					echo esc_html( $name );
+				}
+				if ( '' !== $author ) {
+					/* translators: %s: extension author. */
+					echo ' <span class="description">' . esc_html( sprintf( __( 'by %s', 'agent-connector-for-wp' ), $author ) ) . '</span>';
+				}
+				echo '</li>';
+			}
+			echo '</ul>';
+		}
+
+		if ( ! $shown ) {
+			echo '<span class="description">' . esc_html__( 'None known yet', 'agent-connector-for-wp' ) . '</span>';
+		}
+	}
+
+	/**
+	 * The "Unofficial ability pack" cell — our generated pack (if any) and its
+	 * Install & Activate / Enable / Disable actions.
 	 *
 	 * @param array<string,mixed> $row A single PluginDirectory overview row.
 	 */
-	private function render_pack_cells( array $row ): void {
+	private function render_pack_cell( array $row ): void {
+		if ( empty( $row['has_pack'] ) ) {
+			echo '<span class="description">' . esc_html__( 'None available', 'agent-connector-for-wp' ) . '</span>';
+			return;
+		}
+
 		$entry        = (array) $row['entry'];
 		$pack_name    = (string) ( $entry['ability_pack_name'] ?? '' );
 		$pack_slug    = (string) ( $entry['ability_pack_slug'] ?? '' );
@@ -182,38 +285,40 @@ final class DirectoryPage {
 		$source_url   = (string) ( $entry['source_url'] ?? '' );
 		$version      = (string) ( $entry['version'] ?? '' );
 		$download_url = (string) ( $entry['download_url'] ?? '' );
-		$can_install  = current_user_can( 'install_plugins' ) && ! ( defined( 'DISALLOW_FILE_MODS' ) && DISALLOW_FILE_MODS );
+		$can_manage   = current_user_can( 'install_plugins' ) && ! ( defined( 'DISALLOW_FILE_MODS' ) && DISALLOW_FILE_MODS );
 		?>
-		<td>
-			<strong>
-				<?php if ( '' !== $source_url ) : ?>
-					<a href="<?php echo esc_url( $source_url ); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html( $pack_name ); ?></a>
-				<?php else : ?>
-					<?php echo esc_html( $pack_name ); ?>
-				<?php endif; ?>
-			</strong>
-			<?php if ( '' !== $version ) : ?>
-				<span class="description">v<?php echo esc_html( $version ); ?></span>
+		<strong>
+			<?php if ( '' !== $source_url ) : ?>
+				<a href="<?php echo esc_url( $source_url ); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html( $pack_name ); ?></a>
+			<?php else : ?>
+				<?php echo esc_html( $pack_name ); ?>
 			<?php endif; ?>
-			<?php if ( '' !== $desc ) : ?>
-				<p class="description" style="margin:.3em 0 0;max-width:40em;"><?php echo esc_html( $desc ); ?></p>
-			<?php endif; ?>
-		</td>
-		<td>
+		</strong>
+		<?php if ( '' !== $version ) : ?>
+			<span class="description">v<?php echo esc_html( $version ); ?></span>
+		<?php endif; ?>
+		<?php if ( '' !== $desc ) : ?>
+			<p class="description" style="margin:.3em 0 .4em;max-width:36em;"><?php echo esc_html( $desc ); ?></p>
+		<?php endif; ?>
+
+		<div style="margin-top:.4em;">
 			<?php if ( $row['pack_active'] ) : ?>
 				<span style="color:#1a7f37;font-weight:600;"><?php esc_html_e( 'Installed &amp; active', 'agent-connector-for-wp' ); ?></span>
+				<?php if ( $can_manage && '' !== $pack_slug ) : ?>
+					<div style="margin-top:.3em;"><?php $this->render_action_form( self::DEACTIVATE_ACTION, $pack_slug, __( 'Disable', 'agent-connector-for-wp' ), 'secondary' ); ?></div>
+				<?php endif; ?>
 			<?php elseif ( $row['pack_installed'] ) : ?>
-				<span style="color:#996800;font-weight:600;"><?php esc_html_e( 'Installed, inactive', 'agent-connector-for-wp' ); ?></span>
-				<?php if ( $can_install && '' !== $pack_slug ) : ?>
-					<div style="margin-top:.4em;"><?php $this->render_action_form( self::ACTIVATE_ACTION, $pack_slug, __( 'Activate', 'agent-connector-for-wp' ), 'secondary' ); ?></div>
+				<span style="color:#996800;font-weight:600;"><?php esc_html_e( 'Installed, disabled', 'agent-connector-for-wp' ); ?></span>
+				<?php if ( $can_manage && '' !== $pack_slug ) : ?>
+					<div style="margin-top:.3em;"><?php $this->render_action_form( self::ACTIVATE_ACTION, $pack_slug, __( 'Enable', 'agent-connector-for-wp' ), 'primary' ); ?></div>
 				<?php endif; ?>
 			<?php else : ?>
-				<span style="color:#2271b1;font-weight:600;"><?php esc_html_e( 'Available to add', 'agent-connector-for-wp' ); ?></span>
-				<?php if ( $can_install && '' !== $pack_slug && '' !== $download_url ) : ?>
-					<div style="margin-top:.4em;"><?php $this->render_action_form( self::INSTALL_ACTION, $pack_slug, __( 'Install', 'agent-connector-for-wp' ), 'primary' ); ?></div>
+				<span style="color:#2271b1;font-weight:600;"><?php esc_html_e( 'Available', 'agent-connector-for-wp' ); ?></span>
+				<?php if ( $can_manage && '' !== $pack_slug && '' !== $download_url ) : ?>
+					<div style="margin-top:.3em;"><?php $this->render_action_form( self::INSTALL_ACTION, $pack_slug, __( 'Install &amp; Activate', 'agent-connector-for-wp' ), 'primary' ); ?></div>
 				<?php endif; ?>
 			<?php endif; ?>
-		</td>
+		</div>
 		<?php
 	}
 
@@ -301,6 +406,29 @@ final class DirectoryPage {
 
 		PluginDirectory::clear_cache();
 		$this->redirect( is_wp_error( $result ) ? 'install_failed' : 'activated' );
+	}
+
+	/**
+	 * admin-post: deactivate (disable) an installed ability pack.
+	 */
+	public function handle_deactivate(): void {
+		$this->verify( self::DEACTIVATE_ACTION );
+
+		if ( ! current_user_can( 'activate_plugins' ) ) {
+			$this->redirect( 'install_failed' );
+		}
+
+		$slug = isset( $_POST['pack_slug'] ) ? sanitize_text_field( wp_unslash( $_POST['pack_slug'] ) ) : '';
+		$file = PluginDirectory::installed_file_for_slug( $slug );
+		if ( null === $file ) {
+			$this->redirect( 'install_failed' );
+		}
+
+		require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		deactivate_plugins( $file, true );
+
+		PluginDirectory::clear_cache();
+		$this->redirect( 'disabled' );
 	}
 
 	/**
@@ -397,14 +525,116 @@ final class DirectoryPage {
 	}
 
 	/**
+	 * The "Registered Abilities" tab: every ability currently registered through
+	 * the WP Abilities API, with full detail. Read-only.
+	 */
+	private function render_abilities_tab(): void {
+		$abilities = function_exists( 'wp_get_abilities' ) ? (array) wp_get_abilities() : array();
+		?>
+		<p style="max-width:52em;">
+			<?php esc_html_e( 'Every ability registered on this site through the WordPress Abilities API. Abilities whose plugin is inactive (or whose code is gated off) are not registered and so do not appear here. Those marked “Exposed via MCP” are surfaced to connected agents while the plugin is enabled.', 'agent-connector-for-wp' ); ?>
+		</p>
+		<?php
+		if ( empty( $abilities ) ) {
+			echo '<p><em>' . esc_html__( 'No abilities are registered yet.', 'agent-connector-for-wp' ) . '</em></p>';
+			return;
+		}
+
+		usort(
+			$abilities,
+			static function ( $a, $b ): int {
+				$ca = method_exists( $a, 'get_category' ) ? (string) $a->get_category() : '';
+				$cb = method_exists( $b, 'get_category' ) ? (string) $b->get_category() : '';
+				if ( $ca !== $cb ) {
+					return strcasecmp( $ca, $cb );
+				}
+				return strcasecmp( (string) $a->get_name(), (string) $b->get_name() );
+			}
+		);
+		?>
+		<table class="widefat striped" style="margin-top:1em;">
+			<thead>
+				<tr>
+					<th scope="col"><?php esc_html_e( 'Ability', 'agent-connector-for-wp' ); ?></th>
+					<th scope="col"><?php esc_html_e( 'Category', 'agent-connector-for-wp' ); ?></th>
+					<th scope="col"><?php esc_html_e( 'Exposed via MCP', 'agent-connector-for-wp' ); ?></th>
+					<th scope="col"><?php esc_html_e( 'Details', 'agent-connector-for-wp' ); ?></th>
+				</tr>
+			</thead>
+			<tbody>
+				<?php foreach ( $abilities as $ability ) : ?>
+					<?php $this->render_ability_row( $ability ); ?>
+				<?php endforeach; ?>
+			</tbody>
+		</table>
+		<?php
+	}
+
+	/**
+	 * Render one ability row with its full detail (schemas, meta).
+	 *
+	 * @param object $ability A WP_Ability instance.
+	 */
+	private function render_ability_row( $ability ): void {
+		$name        = (string) $ability->get_name();
+		$label       = (string) $ability->get_label();
+		$desc        = (string) $ability->get_description();
+		$category    = method_exists( $ability, 'get_category' ) ? (string) $ability->get_category() : '';
+		$meta        = (array) $ability->get_meta();
+		$mcp_public  = isset( $meta['mcp']['public'] ) && true === $meta['mcp']['public'];
+		$annotations = isset( $meta['annotations'] ) && is_array( $meta['annotations'] ) ? $meta['annotations'] : array();
+		$input       = $ability->get_input_schema();
+		$output      = method_exists( $ability, 'get_output_schema' ) ? $ability->get_output_schema() : null;
+
+		$json = static function ( $data ): string {
+			return (string) wp_json_encode( $data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );
+		};
+		?>
+		<tr>
+			<td>
+				<strong><?php echo esc_html( '' !== $label ? $label : $name ); ?></strong><br />
+				<code style="font-size:11px;"><?php echo esc_html( $name ); ?></code>
+				<?php if ( '' !== $desc ) : ?>
+					<p class="description" style="margin:.3em 0 0;max-width:40em;"><?php echo esc_html( $desc ); ?></p>
+				<?php endif; ?>
+			</td>
+			<td><?php echo '' !== $category ? esc_html( $category ) : '<span class="description">—</span>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></td>
+			<td>
+				<?php if ( $mcp_public ) : ?>
+					<span style="color:#1a7f37;font-weight:600;"><?php esc_html_e( 'Yes', 'agent-connector-for-wp' ); ?></span>
+				<?php else : ?>
+					<span class="description"><?php esc_html_e( 'No', 'agent-connector-for-wp' ); ?></span>
+				<?php endif; ?>
+			</td>
+			<td>
+				<details>
+					<summary style="cursor:pointer;"><?php esc_html_e( 'Schemas & meta', 'agent-connector-for-wp' ); ?></summary>
+					<?php if ( ! empty( $annotations ) ) : ?>
+						<p style="margin:.5em 0 0;"><strong><?php esc_html_e( 'Annotations', 'agent-connector-for-wp' ); ?></strong></p>
+						<pre style="white-space:pre-wrap;max-width:48em;background:#f6f7f7;padding:.6em;overflow:auto;"><?php echo esc_html( $json( $annotations ) ); ?></pre>
+					<?php endif; ?>
+					<p style="margin:.5em 0 0;"><strong><?php esc_html_e( 'Input schema', 'agent-connector-for-wp' ); ?></strong></p>
+					<pre style="white-space:pre-wrap;max-width:48em;background:#f6f7f7;padding:.6em;overflow:auto;"><?php echo esc_html( $json( $input ) ); ?></pre>
+					<?php if ( ! empty( $output ) ) : ?>
+						<p style="margin:.5em 0 0;"><strong><?php esc_html_e( 'Output schema', 'agent-connector-for-wp' ); ?></strong></p>
+						<pre style="white-space:pre-wrap;max-width:48em;background:#f6f7f7;padding:.6em;overflow:auto;"><?php echo esc_html( $json( $output ) ); ?></pre>
+					<?php endif; ?>
+				</details>
+			</td>
+		</tr>
+		<?php
+	}
+
+	/**
 	 * Render the result notice for a given notice key (post-redirect-get).
 	 */
 	private function render_notice( string $notice ): void {
 		$map = array(
 			'refreshed'      => array( 'success', __( 'Directory refreshed.', 'agent-connector-for-wp' ) ),
 			'installed'      => array( 'success', __( 'Ability pack installed and activated.', 'agent-connector-for-wp' ) ),
-			'activated'      => array( 'success', __( 'Ability pack activated.', 'agent-connector-for-wp' ) ),
-			'install_failed' => array( 'error', __( 'Could not install the ability pack. Check that it is available and that this site can install plugins.', 'agent-connector-for-wp' ) ),
+			'activated'      => array( 'success', __( 'Ability pack enabled.', 'agent-connector-for-wp' ) ),
+			'disabled'       => array( 'success', __( 'Ability pack disabled.', 'agent-connector-for-wp' ) ),
+			'install_failed' => array( 'error', __( 'Could not complete that action. Check that the pack is available and that this site can install/activate plugins.', 'agent-connector-for-wp' ) ),
 			'fs_unavailable' => array( 'error', __( 'This site cannot install plugins directly (no direct filesystem access). Install the pack zip manually instead.', 'agent-connector-for-wp' ) ),
 		);
 		if ( ! isset( $map[ $notice ] ) ) {

--- a/plugin/src/Admin/DirectoryPage.php
+++ b/plugin/src/Admin/DirectoryPage.php
@@ -262,7 +262,7 @@ final class DirectoryPage {
 		}
 
 		if ( ! $shown ) {
-			echo '<span class="description">' . esc_html__( 'None known yet', 'agent-connector-for-wp' ) . '</span>';
+			echo '<span class="description">' . esc_html__( 'Unknown', 'agent-connector-for-wp' ) . '</span>';
 		}
 	}
 
@@ -524,54 +524,148 @@ final class DirectoryPage {
 		<?php
 	}
 
+	/** How many abilities to show per page on the Registered Abilities tab. */
+	private const ABILITIES_PER_PAGE = 50;
+
 	/**
-	 * The "Registered Abilities" tab: every ability currently registered through
-	 * the WP Abilities API, with full detail. Read-only.
+	 * The "Registered Abilities" tab: a compact, searchable, paginated list of
+	 * every ability registered through the WP Abilities API. One line each; full
+	 * detail (schemas + meta) lives in a collapsed disclosure per row.
+	 *
+	 * Built to stay light with very large registries (e.g. 100 plugins ×
+	 * 100 abilities): we filter in a single pass, sort names (strings, not
+	 * objects), and only ever render one page (<= ABILITIES_PER_PAGE) of rows, so
+	 * the DOM and the rendered schema markup stay bounded regardless of the total.
 	 */
 	private function render_abilities_tab(): void {
-		$abilities = function_exists( 'wp_get_abilities' ) ? (array) wp_get_abilities() : array();
+		$all = function_exists( 'wp_get_abilities' ) ? (array) wp_get_abilities() : array();
+
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended -- read-only GET navigation.
+		$search = isset( $_GET['ability_s'] ) ? sanitize_text_field( wp_unslash( $_GET['ability_s'] ) ) : '';
+		$paged  = isset( $_GET['ability_paged'] ) ? max( 1, (int) $_GET['ability_paged'] ) : 1;
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
+		$needle = strtolower( $search );
+
+		// Single pass: filter + key by name (names are unique).
+		$keyed = array();
+		foreach ( $all as $ability ) {
+			if ( ! is_object( $ability ) || ! method_exists( $ability, 'get_name' ) ) {
+				continue;
+			}
+			if ( '' !== $needle ) {
+				$category = method_exists( $ability, 'get_category' ) ? (string) $ability->get_category() : '';
+				$hay      = strtolower( $ability->get_name() . ' ' . $ability->get_label() . ' ' . $ability->get_description() . ' ' . $category );
+				if ( false === strpos( $hay, $needle ) ) {
+					continue;
+				}
+			}
+			$keyed[ (string) $ability->get_name() ] = $ability;
+		}
+
+		$names = array_keys( $keyed );
+		sort( $names, SORT_NATURAL | SORT_FLAG_CASE ); // Cheap: strings, not objects.
+
+		$total    = count( $names );
+		$pages    = (int) max( 1, (int) ceil( $total / self::ABILITIES_PER_PAGE ) );
+		$paged    = min( $paged, $pages );
+		$offset   = ( $paged - 1 ) * self::ABILITIES_PER_PAGE;
+		$page_set = array_slice( $names, $offset, self::ABILITIES_PER_PAGE );
+
+		$base = add_query_arg(
+			array(
+				'page' => self::MENU_SLUG,
+				'tab'  => 'abilities',
+			),
+			admin_url( 'admin.php' )
+		);
 		?>
 		<p style="max-width:52em;">
 			<?php esc_html_e( 'Every ability registered on this site through the WordPress Abilities API. Abilities whose plugin is inactive (or whose code is gated off) are not registered and so do not appear here. Those marked “Exposed via MCP” are surfaced to connected agents while the plugin is enabled.', 'agent-connector-for-wp' ); ?>
 		</p>
-		<?php
-		if ( empty( $abilities ) ) {
-			echo '<p><em>' . esc_html__( 'No abilities are registered yet.', 'agent-connector-for-wp' ) . '</em></p>';
-			return;
-		}
 
-		usort(
-			$abilities,
-			static function ( $a, $b ): int {
-				$ca = method_exists( $a, 'get_category' ) ? (string) $a->get_category() : '';
-				$cb = method_exists( $b, 'get_category' ) ? (string) $b->get_category() : '';
-				if ( $ca !== $cb ) {
-					return strcasecmp( $ca, $cb );
-				}
-				return strcasecmp( (string) $a->get_name(), (string) $b->get_name() );
-			}
-		);
-		?>
-		<table class="widefat striped" style="margin-top:1em;">
+		<form method="get" style="margin:.5em 0 1em;">
+			<input type="hidden" name="page" value="<?php echo esc_attr( self::MENU_SLUG ); ?>" />
+			<input type="hidden" name="tab" value="abilities" />
+			<input type="search" name="ability_s" value="<?php echo esc_attr( $search ); ?>" placeholder="<?php esc_attr_e( 'Search abilities…', 'agent-connector-for-wp' ); ?>" style="min-width:22em;" />
+			<?php submit_button( __( 'Search', 'agent-connector-for-wp' ), 'secondary', '', false ); ?>
+			<?php if ( '' !== $search ) : ?>
+				<a href="<?php echo esc_url( $base ); ?>" class="button-link" style="margin-left:.5em;"><?php esc_html_e( 'Clear', 'agent-connector-for-wp' ); ?></a>
+			<?php endif; ?>
+		</form>
+
+		<?php if ( 0 === $total ) : ?>
+			<p><em><?php echo '' !== $search ? esc_html__( 'No abilities match your search.', 'agent-connector-for-wp' ) : esc_html__( 'No abilities are registered yet.', 'agent-connector-for-wp' ); ?></em></p>
+			<?php return; ?>
+		<?php endif; ?>
+
+		<p class="description">
+			<?php
+			printf(
+				/* translators: 1: first row number, 2: last row number, 3: total count. */
+				esc_html__( 'Showing %1$d–%2$d of %3$d abilities.', 'agent-connector-for-wp' ),
+				(int) ( $offset + 1 ),
+				(int) min( $offset + self::ABILITIES_PER_PAGE, $total ),
+				(int) $total
+			);
+			?>
+		</p>
+
+		<table class="widefat striped" style="margin-top:.5em;">
 			<thead>
 				<tr>
-					<th scope="col"><?php esc_html_e( 'Ability', 'agent-connector-for-wp' ); ?></th>
+					<th scope="col" style="width:48%;"><?php esc_html_e( 'Ability', 'agent-connector-for-wp' ); ?></th>
 					<th scope="col"><?php esc_html_e( 'Category', 'agent-connector-for-wp' ); ?></th>
-					<th scope="col"><?php esc_html_e( 'Exposed via MCP', 'agent-connector-for-wp' ); ?></th>
+					<th scope="col"><?php esc_html_e( 'MCP', 'agent-connector-for-wp' ); ?></th>
 					<th scope="col"><?php esc_html_e( 'Details', 'agent-connector-for-wp' ); ?></th>
 				</tr>
 			</thead>
 			<tbody>
-				<?php foreach ( $abilities as $ability ) : ?>
-					<?php $this->render_ability_row( $ability ); ?>
+				<?php foreach ( $page_set as $name ) : ?>
+					<?php $this->render_ability_row( $keyed[ $name ] ); ?>
 				<?php endforeach; ?>
 			</tbody>
 		</table>
+
+		<?php $this->render_abilities_pagination( $base, $search, $paged, $pages ); ?>
 		<?php
 	}
 
 	/**
-	 * Render one ability row with its full detail (schemas, meta).
+	 * Prev/next pager for the Registered Abilities tab (preserves the search term).
+	 */
+	private function render_abilities_pagination( string $base, string $search, int $paged, int $pages ): void {
+		if ( $pages < 2 ) {
+			return;
+		}
+		$extra = '' !== $search ? array( 'ability_s' => $search ) : array();
+		$link  = static function ( int $p ) use ( $base, $extra ): string {
+			return esc_url( add_query_arg( array_merge( $extra, array( 'ability_paged' => $p ) ), $base ) );
+		};
+		?>
+		<p style="margin-top:1em;">
+			<?php if ( $paged > 1 ) : ?>
+				<a class="button" href="<?php echo $link( $paged - 1 ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>">&larr; <?php esc_html_e( 'Previous', 'agent-connector-for-wp' ); ?></a>
+			<?php endif; ?>
+			<span class="description" style="margin:0 .6em;">
+				<?php
+				printf(
+					/* translators: 1: current page, 2: total pages. */
+					esc_html__( 'Page %1$d of %2$d', 'agent-connector-for-wp' ),
+					(int) $paged,
+					(int) $pages
+				);
+				?>
+			</span>
+			<?php if ( $paged < $pages ) : ?>
+				<a class="button" href="<?php echo $link( $paged + 1 ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>"><?php esc_html_e( 'Next', 'agent-connector-for-wp' ); ?> &rarr;</a>
+			<?php endif; ?>
+		</p>
+		<?php
+	}
+
+	/**
+	 * Render one compact ability row: a single line (label, name, category, MCP)
+	 * with a collapsed disclosure holding the description + schemas + meta.
 	 *
 	 * @param object $ability A WP_Ability instance.
 	 */
@@ -586,17 +680,17 @@ final class DirectoryPage {
 		$input       = $ability->get_input_schema();
 		$output      = method_exists( $ability, 'get_output_schema' ) ? $ability->get_output_schema() : null;
 
+		$pre  = 'white-space:pre-wrap;max-width:48em;background:#f6f7f7;padding:.6em;overflow:auto;';
 		$json = static function ( $data ): string {
 			return (string) wp_json_encode( $data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );
 		};
 		?>
 		<tr>
 			<td>
-				<strong><?php echo esc_html( '' !== $label ? $label : $name ); ?></strong><br />
-				<code style="font-size:11px;"><?php echo esc_html( $name ); ?></code>
-				<?php if ( '' !== $desc ) : ?>
-					<p class="description" style="margin:.3em 0 0;max-width:40em;"><?php echo esc_html( $desc ); ?></p>
+				<?php if ( '' !== $label && $label !== $name ) : ?>
+					<strong><?php echo esc_html( $label ); ?></strong>
 				<?php endif; ?>
+				<code style="font-size:11px;"><?php echo esc_html( $name ); ?></code>
 			</td>
 			<td><?php echo '' !== $category ? esc_html( $category ) : '<span class="description">—</span>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></td>
 			<td>
@@ -608,16 +702,19 @@ final class DirectoryPage {
 			</td>
 			<td>
 				<details>
-					<summary style="cursor:pointer;"><?php esc_html_e( 'Schemas & meta', 'agent-connector-for-wp' ); ?></summary>
+					<summary style="cursor:pointer;"><?php esc_html_e( 'View', 'agent-connector-for-wp' ); ?></summary>
+					<?php if ( '' !== $desc ) : ?>
+						<p class="description" style="margin:.5em 0 0;max-width:48em;"><?php echo esc_html( $desc ); ?></p>
+					<?php endif; ?>
 					<?php if ( ! empty( $annotations ) ) : ?>
 						<p style="margin:.5em 0 0;"><strong><?php esc_html_e( 'Annotations', 'agent-connector-for-wp' ); ?></strong></p>
-						<pre style="white-space:pre-wrap;max-width:48em;background:#f6f7f7;padding:.6em;overflow:auto;"><?php echo esc_html( $json( $annotations ) ); ?></pre>
+						<pre style="<?php echo esc_attr( $pre ); ?>"><?php echo esc_html( $json( $annotations ) ); ?></pre>
 					<?php endif; ?>
 					<p style="margin:.5em 0 0;"><strong><?php esc_html_e( 'Input schema', 'agent-connector-for-wp' ); ?></strong></p>
-					<pre style="white-space:pre-wrap;max-width:48em;background:#f6f7f7;padding:.6em;overflow:auto;"><?php echo esc_html( $json( $input ) ); ?></pre>
+					<pre style="<?php echo esc_attr( $pre ); ?>"><?php echo esc_html( $json( $input ) ); ?></pre>
 					<?php if ( ! empty( $output ) ) : ?>
 						<p style="margin:.5em 0 0;"><strong><?php esc_html_e( 'Output schema', 'agent-connector-for-wp' ); ?></strong></p>
-						<pre style="white-space:pre-wrap;max-width:48em;background:#f6f7f7;padding:.6em;overflow:auto;"><?php echo esc_html( $json( $output ) ); ?></pre>
+						<pre style="<?php echo esc_attr( $pre ); ?>"><?php echo esc_html( $json( $output ) ); ?></pre>
 					<?php endif; ?>
 				</details>
 			</td>

--- a/plugin/src/Services/PluginDirectory.php
+++ b/plugin/src/Services/PluginDirectory.php
@@ -102,16 +102,21 @@ final class PluginDirectory {
 		$url = self::directory_url();
 		$fp  = self::installed_fingerprint();
 
+		$cached_statuses = static function ( array $cached ): array {
+			return isset( $cached['statuses'] ) && is_array( $cached['statuses'] ) ? $cached['statuses'] : array();
+		};
+
 		if ( ! $force ) {
 			$cached = self::cached();
 			// Only serve the cache when it was built for the same installed-plugin
 			// set; otherwise a newly installed plugin would stay hidden for 12h.
 			if ( null !== $cached && isset( $cached['fp'] ) && $cached['fp'] === $fp ) {
 				return array(
-					'entries' => $cached['entries'],
-					'stale'   => false,
-					'error'   => '',
-					'url'     => $url,
+					'entries'  => $cached['entries'],
+					'statuses' => $cached_statuses( $cached ),
+					'stale'    => false,
+					'error'    => '',
+					'url'      => $url,
 				);
 			}
 		}
@@ -119,13 +124,22 @@ final class PluginDirectory {
 		$fetched = self::fetch( $url );
 
 		if ( null !== $fetched ) {
-			set_transient( self::CACHE_KEY, array( 'fp' => $fp, 'entries' => $fetched ), self::CACHE_TTL );
+			set_transient(
+				self::CACHE_KEY,
+				array(
+					'fp'       => $fp,
+					'entries'  => $fetched['entries'],
+					'statuses' => $fetched['statuses'],
+				),
+				self::CACHE_TTL
+			);
 
 			return array(
-				'entries' => $fetched,
-				'stale'   => false,
-				'error'   => '',
-				'url'     => $url,
+				'entries'  => $fetched['entries'],
+				'statuses' => $fetched['statuses'],
+				'stale'    => false,
+				'error'    => '',
+				'url'      => $url,
 			);
 		}
 
@@ -134,18 +148,20 @@ final class PluginDirectory {
 		$cached = self::cached();
 		if ( null !== $cached ) {
 			return array(
-				'entries' => $cached['entries'],
-				'stale'   => true,
-				'error'   => __( 'Could not refresh the directory; showing the last cached copy.', 'agent-connector-for-wp' ),
-				'url'     => $url,
+				'entries'  => $cached['entries'],
+				'statuses' => $cached_statuses( $cached ),
+				'stale'    => true,
+				'error'    => __( 'Could not refresh the directory; showing the last cached copy.', 'agent-connector-for-wp' ),
+				'url'      => $url,
 			);
 		}
 
 		return array(
-			'entries' => array(),
-			'stale'   => false,
-			'error'   => __( 'The ability-pack directory is currently unavailable.', 'agent-connector-for-wp' ),
-			'url'     => $url,
+			'entries'  => array(),
+			'statuses' => array(),
+			'stale'    => false,
+			'error'    => __( 'The ability-pack directory is currently unavailable.', 'agent-connector-for-wp' ),
+			'url'      => $url,
 		);
 	}
 
@@ -161,7 +177,8 @@ final class PluginDirectory {
 	 *
 	 * @param string $url Directory URL.
 	 *
-	 * @return array<int,array<string,string>>|null Normalized entries, or null on any failure.
+	 * @return array{entries:array<int,array<string,string>>,statuses:array<string,array<string,mixed>>}|null
+	 *         Normalized entries + per-slug statuses, or null on any failure.
 	 */
 	private static function fetch( string $url ): ?array {
 		if ( '' === $url || ! function_exists( 'wp_remote_post' ) ) {
@@ -219,23 +236,83 @@ final class PluginDirectory {
 	 * @return array<int,array<string,string>>
 	 */
 	private static function normalize( $decoded ): array {
+		$raw_entries  = array();
+		$raw_statuses = array();
+
 		if ( is_array( $decoded ) && isset( $decoded['entries'] ) && is_array( $decoded['entries'] ) ) {
-			$raw = $decoded['entries'];
+			$raw_entries = $decoded['entries'];
+			if ( isset( $decoded['statuses'] ) && is_array( $decoded['statuses'] ) ) {
+				$raw_statuses = $decoded['statuses'];
+			}
 		} elseif ( is_array( $decoded ) ) {
-			$raw = $decoded;
-		} else {
-			return array();
+			$raw_entries = $decoded;
 		}
 
 		$entries = array();
-		foreach ( $raw as $item ) {
+		foreach ( $raw_entries as $item ) {
 			$entry = self::normalize_entry( $item );
 			if ( null !== $entry ) {
 				$entries[] = $entry;
 			}
 		}
 
-		return $entries;
+		return array(
+			'entries'  => $entries,
+			'statuses' => self::normalize_status_map( $raw_statuses ),
+		);
+	}
+
+	/**
+	 * Normalize the per-plugin AI-status list into a map keyed by plugin slug.
+	 *
+	 * Each value: level, official_since, official_docs_url, abilities_count, and
+	 * unofficial_plugins[] (name, plugin_url, description, author, author_url).
+	 *
+	 * @param array<int,mixed> $raw Raw statuses array from the endpoint.
+	 *
+	 * @return array<string,array<string,mixed>>
+	 */
+	private static function normalize_status_map( array $raw ): array {
+		$str = static function ( $value ): string {
+			return is_string( $value ) ? trim( $value ) : '';
+		};
+
+		$out = array();
+		foreach ( $raw as $item ) {
+			if ( ! is_array( $item ) ) {
+				continue;
+			}
+			$slug = $str( $item['slug'] ?? '' );
+			if ( '' === $slug ) {
+				continue;
+			}
+
+			$unofficial = array();
+			if ( isset( $item['unofficial_plugins'] ) && is_array( $item['unofficial_plugins'] ) ) {
+				foreach ( $item['unofficial_plugins'] as $u ) {
+					if ( ! is_array( $u ) || '' === $str( $u['name'] ?? '' ) ) {
+						continue;
+					}
+					$unofficial[] = array(
+						'name'        => $str( $u['name'] ?? '' ),
+						'plugin_url'  => $str( $u['plugin_url'] ?? '' ),
+						'description' => $str( $u['description'] ?? '' ),
+						'author'      => $str( $u['author'] ?? '' ),
+						'author_url'  => $str( $u['author_url'] ?? '' ),
+					);
+				}
+			}
+
+			$out[ $slug ] = array(
+				'level'              => $str( $item['level'] ?? '' ),
+				'official_since'     => $str( $item['official_since'] ?? '' ),
+				'official_docs_url'  => $str( $item['official_docs_url'] ?? '' ),
+				'abilities_count'    => isset( $item['abilities_count'] ) && is_numeric( $item['abilities_count'] ) ? (int) $item['abilities_count'] : 0,
+				'unofficial_plugins' => $unofficial,
+			);
+		}
+
+		return $out;
 	}
 
 	/**
@@ -348,8 +425,9 @@ final class PluginDirectory {
 	 * joined with its available ability pack when one exists. Drives the admin
 	 * screen so plugins without a pack are still listed.
 	 *
-	 * Each row: plugin_file, plugin_name, plugin_active, has_pack, and — when
-	 * has_pack — entry / pack_installed / pack_active (as in match_installed()).
+	 * Only ACTIVE plugins are included. Each row: plugin_file, plugin_name,
+	 * plugin_active, has_pack, ai_status (level, official fields, unofficial_plugins;
+	 * may be empty), and — when has_pack — entry / pack_installed / pack_active.
 	 *
 	 * @return array{
 	 *     rows: array<int,array<string,mixed>>,
@@ -360,7 +438,8 @@ final class PluginDirectory {
 	 * }
 	 */
 	public static function installed_overview( bool $force = false ): array {
-		$result = self::get( $force );
+		$result   = self::get( $force );
+		$statuses = isset( $result['statuses'] ) && is_array( $result['statuses'] ) ? $result['statuses'] : array();
 
 		$by_file = array();
 		foreach ( self::match_installed( $result['entries'] ) as $match ) {
@@ -372,37 +451,45 @@ final class PluginDirectory {
 			if ( self::is_self_or_pack( $file, $data ) ) {
 				continue;
 			}
-
-			$name   = (string) ( $data['Name'] ?? $file );
-			$active = self::is_active( $file );
+			if ( ! self::is_active( $file ) ) {
+				continue; // Active plugins only.
+			}
 
 			if ( isset( $by_file[ $file ] ) ) {
-				$row                  = $by_file[ $file ];
-				$row['has_pack']      = true;
-				$row['plugin_file']   = $file;
-				$row['plugin_name']   = $name;
-				$row['plugin_active'] = $active;
+				$row             = $by_file[ $file ];
+				$row['has_pack'] = true;
 			} else {
 				$row = array(
 					'has_pack'       => false,
-					'plugin_file'    => $file,
-					'plugin_name'    => $name,
-					'plugin_active'  => $active,
 					'entry'          => array(),
 					'pack_installed' => false,
 					'pack_active'    => false,
 				);
 			}
 
+			$row['plugin_file']   = $file;
+			$row['plugin_name']   = (string) ( $data['Name'] ?? $file );
+			$row['plugin_active'] = true;
+			$row['ai_status']     = $statuses[ self::folder_slug( $file ) ] ?? array();
+
 			$rows[] = $row;
 		}
 
-		// Plugins with an available pack first, then alphabetically by name.
+		// Rank: our pack available first, then any known AI status, then the rest;
+		// alphabetical within each group.
 		usort(
 			$rows,
 			static function ( array $a, array $b ): int {
-				if ( $a['has_pack'] !== $b['has_pack'] ) {
-					return $a['has_pack'] ? -1 : 1;
+				$rank = static function ( array $r ): int {
+					if ( ! empty( $r['has_pack'] ) ) {
+						return 0;
+					}
+					return self::row_has_ai_info( $r ) ? 1 : 2;
+				};
+				$ra = $rank( $a );
+				$rb = $rank( $b );
+				if ( $ra !== $rb ) {
+					return $ra <=> $rb;
 				}
 				return strcasecmp( (string) $a['plugin_name'], (string) $b['plugin_name'] );
 			}
@@ -415,6 +502,20 @@ final class PluginDirectory {
 			'url'   => $result['url'],
 			'total' => count( $result['entries'] ),
 		);
+	}
+
+	/**
+	 * Whether a row's ai_status indicates any known official/third-party support.
+	 *
+	 * @param array<string,mixed> $row Overview row.
+	 */
+	public static function row_has_ai_info( array $row ): bool {
+		$s = isset( $row['ai_status'] ) && is_array( $row['ai_status'] ) ? $row['ai_status'] : array();
+		$level = (string) ( $s['level'] ?? '' );
+		if ( in_array( $level, array( 'official', 'unofficial', 'coming_soon' ), true ) ) {
+			return true;
+		}
+		return ! empty( $s['unofficial_plugins'] );
 	}
 
 	/**


### PR DESCRIPTION
Part 2 of the redesign (pairs with the tracker PR #18). Reworks the **Ability Packs** screen into an **Abilities** page with two tabs. **Touches `plugin/**` → cuts a plugin release when *you* merge.**

## Ability Packs tab
- **Active plugins only** (drops inactive rows + the "(installed, not active)" text).
- New **Available AI abilities** column from the tracker: **official** built-in (green badge + version + docs), **third-party** unofficial extensions (informational links, e.g. GravityMCP), **coming soon**, or **None known yet**.
- **Unofficial ability pack** column (ours, always optional): **Install & Activate** when absent, **Enable** when installed-disabled, **Installed & active + Disable** when active. New `handle_deactivate()`. Cap + `install_plugins`/`activate_plugins` + nonce; **no delete** (per decision).

## Registered Abilities tab
- Lists every ability from `wp_get_abilities()` with **full detail**: name, label, description, category, **Exposed via MCP** (`meta.mcp.public`), annotations, and collapsible input/output JSON schemas. Abilities from inactive/inert plugins aren't registered, so they don't appear (expected).

## PluginDirectory
- Threads the endpoint's new `statuses` through fetch/normalize/cache/get; `installed_overview()` is active-only and attaches `ai_status` per plugin. **Degrades gracefully** if the endpoint returns no `statuses` (availability shows "None known yet").

## Verification (in-sandbox)
- `php -l` clean; site loads with no fatals.
- Packs tab (seeded statuses): official badge + `since v6.0`, coming-soon, third-party list, "None known yet", our pack + Disable, tabs all render. ✅
- Abilities tab: 30 abilities with schemas, MCP markers, categories. ✅
- `normalize()` unit-tested against the raw API shape (entries + statuses; bad rows dropped). ✅

Depends on #18 for live `statuses`; safe to merge in either order (graceful degrade).

🤖 Generated with [Claude Code](https://claude.com/claude-code)