### PR TITLE
feat(tracker): admin dashboard for managing AI statuses

### DIFF
--- a/agent-ready-plugins-tracker/README.md
+++ b/agent-ready-plugins-tracker/README.md
@@ -49,7 +49,23 @@ ability packs that target any of them:
 ```
 
 It reads the single `pack-index` `index.json` manifest (cached ~10 min) — nothing enumerates
-GitHub's releases — and is allowlisted as public in [`middleware.ts`](middleware.ts).
+GitHub's releases — and is allowlisted as public in [`middleware.ts`](middleware.ts). The
+response also carries a `statuses[]` array with each plugin's AI-support status (see below).
+
+## Admin dashboard
+
+`/admin` is a UI for managing the per-plugin AI status that powers the directory and the
+`statuses` field of the match API. It's gated by the **`ADMIN_SECRET`** (enter it at
+`/admin/login`; the admin area self-gates independently of the public site password). From it
+you can:
+
+- edit each plugin's status — level (`official` / `unofficial` / `coming_soon` / `none`),
+  official version + docs URL, official abilities, and **third-party unofficial extensions**;
+- add a plugin (a plugin row must exist before its status can be set);
+- triage pending **submissions** (mark reviewed).
+
+Writes go through server actions that re-check the admin session; the older
+`PUT /api/admin/status` (bearer-token) endpoint still works for scripted updates.
 
 ## Database
 

--- a/agent-ready-plugins-tracker/app/admin/AdminClient.tsx
+++ b/agent-ready-plugins-tracker/app/admin/AdminClient.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import type { Plugin, Submission } from "@/lib/types";
+import { addPluginAction, reviewSubmissionAction } from "./actions";
+
+const input =
+  "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-wp-blue focus:outline-none focus:ring-1 focus:ring-wp-blue";
+
+export function LogoutButton() {
+  const router = useRouter();
+  return (
+    <button
+      onClick={async () => {
+        await fetch("/api/admin/login", { method: "DELETE" });
+        router.push("/admin/login");
+        router.refresh();
+      }}
+      className="rounded-md border border-slate-300 px-3 py-1.5 text-sm font-medium hover:bg-slate-50"
+    >
+      Log out
+    </button>
+  );
+}
+
+export function AddPluginForm() {
+  const router = useRouter();
+  const [slug, setSlug] = useState("");
+  const [name, setName] = useState("");
+  const [tagline, setTagline] = useState("");
+  const [author, setAuthor] = useState("");
+  const [wpOrgUrl, setWpOrgUrl] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [msg, setMsg] = useState("");
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!slug.trim() || !name.trim()) return;
+    setBusy(true);
+    setMsg("");
+    const plugin: Plugin = {
+      slug: slug.trim(),
+      name: name.trim(),
+      tagline: tagline.trim(),
+      author: author.trim(),
+      wpOrgUrl: wpOrgUrl.trim() || undefined,
+      isPremium: false,
+      categories: [],
+      activeInstalls: "",
+    };
+    try {
+      await addPluginAction(plugin);
+      setMsg(`Added ${plugin.slug}.`);
+      setSlug("");
+      setName("");
+      setTagline("");
+      setAuthor("");
+      setWpOrgUrl("");
+      router.refresh();
+    } catch {
+      setMsg("Failed to add plugin.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <form onSubmit={submit} className="grid grid-cols-2 gap-3">
+      <input className={input} value={slug} onChange={(e) => setSlug(e.target.value)} placeholder="slug (e.g. gravityforms) *" />
+      <input className={input} value={name} onChange={(e) => setName(e.target.value)} placeholder="Name *" />
+      <input className={input} value={tagline} onChange={(e) => setTagline(e.target.value)} placeholder="Tagline" />
+      <input className={input} value={author} onChange={(e) => setAuthor(e.target.value)} placeholder="Author" />
+      <input className={input} value={wpOrgUrl} onChange={(e) => setWpOrgUrl(e.target.value)} placeholder="wordpress.org URL" />
+      <div className="flex items-center gap-3">
+        <button type="submit" disabled={busy} className="rounded-lg bg-wp-blue px-4 py-2 text-sm font-semibold text-white hover:bg-wp-blue-dark disabled:opacity-60">
+          {busy ? "Adding…" : "Add plugin"}
+        </button>
+        {msg && <span className="text-sm text-slate-600">{msg}</span>}
+      </div>
+    </form>
+  );
+}
+
+export function SubmissionItem({ submission }: { submission: Submission }) {
+  const router = useRouter();
+  const [busy, setBusy] = useState(false);
+  return (
+    <li className="flex items-start justify-between gap-4 rounded-lg border border-slate-200 p-3">
+      <div className="text-sm">
+        <span className="font-medium text-slate-900">{submission.pluginSlug}</span>{" "}
+        <span className="text-slate-500">· {submission.type}</span>
+        {submission.notes && <p className="mt-1 text-slate-600">{submission.notes}</p>}
+        {submission.submitterEmail && <p className="mt-0.5 text-xs text-slate-400">{submission.submitterEmail}</p>}
+      </div>
+      <button
+        disabled={busy}
+        onClick={async () => {
+          setBusy(true);
+          try {
+            await reviewSubmissionAction(submission.id);
+            router.refresh();
+          } finally {
+            setBusy(false);
+          }
+        }}
+        className="shrink-0 rounded-md border border-slate-300 px-2.5 py-1 text-xs font-medium hover:bg-slate-50 disabled:opacity-60"
+      >
+        {busy ? "…" : "Mark reviewed"}
+      </button>
+    </li>
+  );
+}

--- a/agent-ready-plugins-tracker/app/admin/StatusForm.tsx
+++ b/agent-ready-plugins-tracker/app/admin/StatusForm.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import type { AIStatus, AIStatusLevel, UnofficialPlugin } from "@/lib/types";
+import { saveStatusAction } from "./actions";
+
+const LEVELS: AIStatusLevel[] = ["official", "unofficial", "coming_soon", "none"];
+
+const input =
+  "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-wp-blue focus:outline-none focus:ring-1 focus:ring-wp-blue";
+const labelCls = "mb-1 block text-sm font-medium text-slate-700";
+
+export default function StatusForm({
+  slug,
+  name,
+  initial,
+}: {
+  slug: string;
+  name: string;
+  initial: AIStatus;
+}) {
+  const router = useRouter();
+  const [level, setLevel] = useState<AIStatusLevel>(initial.level ?? "none");
+  const [officialSince, setOfficialSince] = useState(initial.officialSince ?? "");
+  const [officialDocsUrl, setOfficialDocsUrl] = useState(initial.officialDocsUrl ?? "");
+  const [abilitiesCount, setAbilitiesCount] = useState(
+    initial.abilitiesCount != null ? String(initial.abilitiesCount) : ""
+  );
+  const [abilitiesText, setAbilitiesText] = useState((initial.abilities ?? []).join("\n"));
+  const [notes, setNotes] = useState(initial.notes ?? "");
+  const [unofficial, setUnofficial] = useState<UnofficialPlugin[]>(initial.unofficialPlugins ?? []);
+  const [saving, setSaving] = useState(false);
+  const [msg, setMsg] = useState("");
+
+  function setRow(i: number, patch: Partial<UnofficialPlugin>) {
+    setUnofficial((rows) => rows.map((r, idx) => (idx === i ? { ...r, ...patch } : r)));
+  }
+  function addRow() {
+    setUnofficial((rows) => [...rows, { name: "", pluginUrl: "", description: "", author: "" }]);
+  }
+  function removeRow(i: number) {
+    setUnofficial((rows) => rows.filter((_, idx) => idx !== i));
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setSaving(true);
+    setMsg("");
+    const status: AIStatus = {
+      level,
+      officialSince: officialSince.trim() || undefined,
+      officialDocsUrl: officialDocsUrl.trim() || undefined,
+      abilitiesCount: abilitiesCount.trim() ? Number(abilitiesCount) : undefined,
+      abilities: abilitiesText
+        .split(/[\n,]/)
+        .map((s) => s.trim())
+        .filter(Boolean),
+      unofficialPlugins: unofficial
+        .filter((u) => u.name.trim())
+        .map((u) => ({
+          name: u.name.trim(),
+          pluginUrl: u.pluginUrl.trim(),
+          description: u.description.trim(),
+          author: u.author.trim(),
+          authorUrl: u.authorUrl?.trim() || undefined,
+        })),
+      notes: notes.trim() || undefined,
+      lastVerified: initial.lastVerified ?? "",
+    };
+    try {
+      await saveStatusAction(slug, status);
+      setMsg("Saved.");
+      router.refresh();
+    } catch {
+      setMsg("Save failed.");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="mx-auto max-w-3xl px-4 py-8">
+      <Link href="/admin" className="text-sm text-wp-blue hover:underline">
+        ← Back to dashboard
+      </Link>
+      <h1 className="mt-2 text-2xl font-bold text-slate-900">{name}</h1>
+      <p className="mb-6 text-sm text-slate-500">
+        <code>{slug}</code> — AI ability status
+      </p>
+
+      <form onSubmit={handleSubmit} className="space-y-5">
+        <div>
+          <label className={labelCls}>Level</label>
+          <select
+            value={level}
+            onChange={(e) => setLevel(e.target.value as AIStatusLevel)}
+            className={input}
+          >
+            {LEVELS.map((l) => (
+              <option key={l} value={l}>
+                {l}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div className="grid grid-cols-2 gap-4">
+          <div>
+            <label className={labelCls}>Official since (version)</label>
+            <input className={input} value={officialSince} onChange={(e) => setOfficialSince(e.target.value)} placeholder="9.4" />
+          </div>
+          <div>
+            <label className={labelCls}>Abilities count</label>
+            <input className={input} type="number" min="0" value={abilitiesCount} onChange={(e) => setAbilitiesCount(e.target.value)} />
+          </div>
+        </div>
+
+        <div>
+          <label className={labelCls}>Official docs / roadmap URL</label>
+          <input className={input} value={officialDocsUrl} onChange={(e) => setOfficialDocsUrl(e.target.value)} placeholder="https://…" />
+        </div>
+
+        <div>
+          <label className={labelCls}>Official abilities (one per line or comma-separated)</label>
+          <textarea className={input} rows={4} value={abilitiesText} onChange={(e) => setAbilitiesText(e.target.value)} />
+        </div>
+
+        <div>
+          <div className="mb-2 flex items-center justify-between">
+            <label className={labelCls + " mb-0"}>Third-party unofficial extensions</label>
+            <button type="button" onClick={addRow} className="rounded-md border border-slate-300 px-2.5 py-1 text-xs font-medium hover:bg-slate-50">
+              + Add
+            </button>
+          </div>
+          <div className="space-y-3">
+            {unofficial.length === 0 && <p className="text-sm text-slate-400">None.</p>}
+            {unofficial.map((u, i) => (
+              <div key={i} className="rounded-lg border border-slate-200 p-3">
+                <div className="grid grid-cols-2 gap-3">
+                  <input className={input} value={u.name} onChange={(e) => setRow(i, { name: e.target.value })} placeholder="Name *" />
+                  <input className={input} value={u.pluginUrl} onChange={(e) => setRow(i, { pluginUrl: e.target.value })} placeholder="Plugin URL" />
+                  <input className={input} value={u.author} onChange={(e) => setRow(i, { author: e.target.value })} placeholder="Author" />
+                  <input className={input} value={u.authorUrl ?? ""} onChange={(e) => setRow(i, { authorUrl: e.target.value })} placeholder="Author URL" />
+                </div>
+                <textarea className={input + " mt-3"} rows={2} value={u.description} onChange={(e) => setRow(i, { description: e.target.value })} placeholder="Description" />
+                <button type="button" onClick={() => removeRow(i)} className="mt-2 text-xs text-red-600 hover:underline">
+                  Remove
+                </button>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div>
+          <label className={labelCls}>Notes</label>
+          <textarea className={input} rows={2} value={notes} onChange={(e) => setNotes(e.target.value)} />
+        </div>
+
+        <div className="flex items-center gap-3">
+          <button type="submit" disabled={saving} className="rounded-lg bg-wp-blue px-5 py-2.5 font-semibold text-white hover:bg-wp-blue-dark disabled:opacity-60">
+            {saving ? "Saving…" : "Save status"}
+          </button>
+          {msg && <span className="text-sm text-slate-600">{msg}</span>}
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/agent-ready-plugins-tracker/app/admin/actions.ts
+++ b/agent-ready-plugins-tracker/app/admin/actions.ts
@@ -1,0 +1,29 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { isAdmin } from "@/lib/admin-auth";
+import { setAIStatus, upsertPlugin, markSubmissionReviewed } from "@/lib/db";
+import type { AIStatus, Plugin } from "@/lib/types";
+
+async function assertAdmin() {
+  if (!(await isAdmin())) throw new Error("Unauthorized");
+}
+
+export async function saveStatusAction(slug: string, status: AIStatus): Promise<void> {
+  await assertAdmin();
+  await setAIStatus(slug, { ...status, lastVerified: new Date().toISOString().slice(0, 10) });
+  revalidatePath("/admin");
+  revalidatePath(`/admin/plugins/${slug}`);
+}
+
+export async function addPluginAction(plugin: Plugin): Promise<void> {
+  await assertAdmin();
+  await upsertPlugin(plugin);
+  revalidatePath("/admin");
+}
+
+export async function reviewSubmissionAction(id: string): Promise<void> {
+  await assertAdmin();
+  await markSubmissionReviewed(id);
+  revalidatePath("/admin");
+}

--- a/agent-ready-plugins-tracker/app/admin/login/page.tsx
+++ b/agent-ready-plugins-tracker/app/admin/login/page.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+export default function AdminLoginPage() {
+  const router = useRouter();
+  const [secret, setSecret] = useState("");
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setLoading(true);
+    setError("");
+    try {
+      const res = await fetch("/api/admin/login", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ secret }),
+      });
+      if (res.ok) {
+        router.push("/admin");
+        router.refresh();
+      } else {
+        setError("Incorrect admin secret.");
+      }
+    } catch {
+      setError("Something went wrong. Try again.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-slate-50 px-4">
+      <div className="w-full max-w-sm rounded-2xl border border-slate-200 bg-white p-8 shadow-sm">
+        <h1 className="mb-1 text-xl font-bold text-slate-900">Admin access</h1>
+        <p className="mb-6 text-sm text-slate-500">Enter the admin secret to manage AI statuses.</p>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <input
+            type="password"
+            value={secret}
+            onChange={(e) => setSecret(e.target.value)}
+            autoFocus
+            required
+            placeholder="ADMIN_SECRET"
+            className="w-full rounded-lg border border-slate-300 px-4 py-2.5 text-sm focus:border-wp-blue focus:outline-none focus:ring-1 focus:ring-wp-blue"
+          />
+          {error && (
+            <p className="rounded-lg bg-red-50 px-4 py-2.5 text-sm text-red-700">{error}</p>
+          )}
+          <button
+            type="submit"
+            disabled={loading}
+            className="w-full rounded-lg bg-wp-blue py-2.5 font-semibold text-white transition-colors hover:bg-wp-blue-dark disabled:opacity-60"
+          >
+            {loading ? "Checking…" : "Enter"}
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/agent-ready-plugins-tracker/app/admin/page.tsx
+++ b/agent-ready-plugins-tracker/app/admin/page.tsx
@@ -1,0 +1,98 @@
+import Link from "next/link";
+import { requireAdmin } from "@/lib/admin-auth";
+import { getAllPluginsWithStatus, getSubmissions } from "@/lib/db";
+import { AddPluginForm, LogoutButton, SubmissionItem } from "./AdminClient";
+
+export const dynamic = "force-dynamic";
+
+const BADGE: Record<string, string> = {
+  official: "bg-green-100 text-green-800",
+  unofficial: "bg-amber-100 text-amber-800",
+  coming_soon: "bg-blue-100 text-blue-800",
+  none: "bg-slate-100 text-slate-500",
+};
+
+export default async function AdminPage() {
+  await requireAdmin();
+  const plugins = await getAllPluginsWithStatus();
+  const submissions = await getSubmissions();
+  const pending = submissions.filter((s) => !s.reviewed);
+
+  return (
+    <div className="mx-auto max-w-5xl px-4 py-8">
+      <div className="mb-6 flex items-center justify-between">
+        <h1 className="text-2xl font-bold text-slate-900">Admin — AI statuses</h1>
+        <LogoutButton />
+      </div>
+
+      <section className="mb-10">
+        <h2 className="mb-3 text-lg font-semibold text-slate-900">
+          Plugins <span className="text-sm font-normal text-slate-400">({plugins.length})</span>
+        </h2>
+        <div className="overflow-hidden rounded-xl border border-slate-200">
+          <table className="w-full text-sm">
+            <thead className="bg-slate-50 text-left text-slate-500">
+              <tr>
+                <th className="px-4 py-2 font-medium">Plugin</th>
+                <th className="px-4 py-2 font-medium">Level</th>
+                <th className="px-4 py-2 font-medium">Third-party</th>
+                <th className="px-4 py-2"></th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-100">
+              {plugins.map((p) => (
+                <tr key={p.slug}>
+                  <td className="px-4 py-2">
+                    <span className="font-medium text-slate-900">{p.name}</span>{" "}
+                    <code className="text-xs text-slate-400">{p.slug}</code>
+                  </td>
+                  <td className="px-4 py-2">
+                    <span className={`rounded-full px-2 py-0.5 text-xs font-medium ${BADGE[p.aiStatus.level] ?? BADGE.none}`}>
+                      {p.aiStatus.level}
+                    </span>
+                  </td>
+                  <td className="px-4 py-2 text-slate-500">{p.aiStatus.unofficialPlugins.length || "—"}</td>
+                  <td className="px-4 py-2 text-right">
+                    <Link href={`/admin/plugins/${p.slug}`} className="text-wp-blue hover:underline">
+                      Edit
+                    </Link>
+                  </td>
+                </tr>
+              ))}
+              {plugins.length === 0 && (
+                <tr>
+                  <td colSpan={4} className="px-4 py-6 text-center text-slate-400">
+                    No plugins yet. Add one below.
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section className="mb-10">
+        <h2 className="mb-3 text-lg font-semibold text-slate-900">Add a plugin</h2>
+        <p className="mb-3 text-sm text-slate-500">
+          A plugin must exist before you can set its AI status. Add it here, then click Edit above.
+        </p>
+        <AddPluginForm />
+      </section>
+
+      <section>
+        <h2 className="mb-3 text-lg font-semibold text-slate-900">
+          Pending submissions <span className="text-sm font-normal text-slate-400">({pending.length})</span>
+        </h2>
+        {pending.length === 0 ? (
+          <p className="text-sm text-slate-400">Nothing pending.</p>
+        ) : (
+          <ul className="space-y-2">
+            {pending.map((s) => (
+              <SubmissionItem key={s.id} submission={s} />
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/agent-ready-plugins-tracker/app/admin/plugins/[slug]/page.tsx
+++ b/agent-ready-plugins-tracker/app/admin/plugins/[slug]/page.tsx
@@ -1,0 +1,19 @@
+import { notFound } from "next/navigation";
+import { requireAdmin } from "@/lib/admin-auth";
+import { getPluginWithStatus } from "@/lib/db";
+import StatusForm from "../../StatusForm";
+
+export const dynamic = "force-dynamic";
+
+export default async function EditPluginPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  await requireAdmin();
+  const { slug } = await params;
+  const plugin = await getPluginWithStatus(slug);
+  if (!plugin) notFound();
+
+  return <StatusForm slug={slug} name={plugin.name} initial={plugin.aiStatus} />;
+}

--- a/agent-ready-plugins-tracker/app/api/admin/login/route.ts
+++ b/agent-ready-plugins-tracker/app/api/admin/login/route.ts
@@ -1,0 +1,34 @@
+import { NextRequest, NextResponse } from "next/server";
+import { ADMIN_COOKIE } from "@/lib/admin-auth";
+
+// POST /api/admin/login — exchange the ADMIN_SECRET for an admin session cookie.
+export async function POST(req: NextRequest) {
+  if (!process.env.ADMIN_SECRET) {
+    return NextResponse.json({ error: "Admin not configured" }, { status: 503 });
+  }
+  let secret = "";
+  try {
+    ({ secret } = await req.json());
+  } catch {
+    return NextResponse.json({ error: "Invalid body" }, { status: 400 });
+  }
+  if (secret !== process.env.ADMIN_SECRET) {
+    return NextResponse.json({ error: "Wrong secret" }, { status: 401 });
+  }
+  const res = NextResponse.json({ ok: true });
+  res.cookies.set(ADMIN_COOKIE, process.env.ADMIN_SECRET, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
+    maxAge: 60 * 60 * 24 * 30, // 30 days
+    path: "/",
+  });
+  return res;
+}
+
+// DELETE /api/admin/login — clear the admin session.
+export async function DELETE() {
+  const res = NextResponse.json({ ok: true });
+  res.cookies.set(ADMIN_COOKIE, "", { httpOnly: true, path: "/", maxAge: 0 });
+  return res;
+}

--- a/agent-ready-plugins-tracker/lib/admin-auth.ts
+++ b/agent-ready-plugins-tracker/lib/admin-auth.ts
@@ -1,0 +1,18 @@
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+
+/** Cookie holding the admin session (its value is the ADMIN_SECRET). */
+export const ADMIN_COOKIE = "acfw_admin";
+
+/** Whether the current request carries a valid admin session. */
+export async function isAdmin(): Promise<boolean> {
+  const secret = process.env.ADMIN_SECRET;
+  if (!secret) return false;
+  const jar = await cookies();
+  return jar.get(ADMIN_COOKIE)?.value === secret;
+}
+
+/** Redirect to the admin login unless the request is authenticated. */
+export async function requireAdmin(): Promise<void> {
+  if (!(await isAdmin())) redirect("/admin/login");
+}

--- a/agent-ready-plugins-tracker/lib/db.ts
+++ b/agent-ready-plugins-tracker/lib/db.ts
@@ -109,6 +109,13 @@ export async function getSubmissions(): Promise<Submission[]> {
   return data ?? [];
 }
 
+export async function markSubmissionReviewed(id: string): Promise<void> {
+  const supabase = getClient();
+  if (!supabase) throw new Error("Supabase not configured");
+  const { error } = await supabase.from("submissions").update({ reviewed: true }).eq("id", id);
+  if (error) throw error;
+}
+
 // ---- Row converters ----
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/agent-ready-plugins-tracker/middleware.ts
+++ b/agent-ready-plugins-tracker/middleware.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 
-const PUBLIC_PATHS = ["/login", "/api/auth", "/api/seed", "/api/ability-packs"];
+// /admin self-gates on the ADMIN_SECRET (see lib/admin-auth), independent of the
+// public site password; /api/admin routes carry their own checks.
+const PUBLIC_PATHS = ["/login", "/api/auth", "/api/seed", "/api/ability-packs", "/admin", "/api/admin"];
 
 export function middleware(req: NextRequest) {
   const { pathname } = req.nextUrl;


### PR DESCRIPTION
A UI on the tracker to manage the per-plugin **AI status** (official / third-party / coming-soon) that powers the directory and the match endpoint's `statuses` — so you no longer curl the admin API or edit the seed by hand.

## Access
- `/admin/login` exchanges the **`ADMIN_SECRET`** for an httpOnly session cookie. `/admin` self-gates on it, **independent of the public site password** (admins go straight there). `middleware.ts` allowlists `/admin` + `/api/admin`.

## What it does (`/admin`)
- **Plugins list** with status badges → **Edit** per plugin.
- **Status editor**: level (`official`/`unofficial`/`coming_soon`/`none`), official version + docs URL, official abilities list, and repeatable **third-party unofficial extensions** (name/url/author/description) + notes.
- **Add a plugin** (a plugin row must exist before its status can be set).
- **Submissions triage**: list pending submissions, **Mark reviewed**.

## Implementation
- `lib/admin-auth.ts` (`isAdmin`/`requireAdmin`), `app/api/admin/login` (login/logout cookie).
- Writes via **server actions** that re-check the session (`app/admin/actions.ts`); `lib/db` gains `markSubmissionReviewed()`. The existing bearer `PUT /api/admin/status` still works for scripts.

## Verification
`npx tsc --noEmit` clean; `npm run build` succeeds — `/admin` + `/admin/plugins/[slug]` render dynamically, `/admin/login` static.

Needs `ADMIN_SECRET` + Supabase env (already set on the deployment). Opened as a PR — **not merged**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)