### PR TITLE
fix(tracker): surface real admin action errors in the UI

### DIFF
--- a/agent-ready-plugins-tracker/app/admin/AdminClient.tsx
+++ b/agent-ready-plugins-tracker/app/admin/AdminClient.tsx
@@ -49,8 +49,8 @@ export function AddPluginForm() {
       categories: [],
       activeInstalls: "",
     };
-    try {
-      await addPluginAction(plugin);
+    const res = await addPluginAction(plugin);
+    if (res.ok) {
       setMsg(`Added ${plugin.slug}.`);
       setSlug("");
       setName("");
@@ -58,11 +58,10 @@ export function AddPluginForm() {
       setAuthor("");
       setWpOrgUrl("");
       router.refresh();
-    } catch {
-      setMsg("Failed to add plugin.");
-    } finally {
-      setBusy(false);
+    } else {
+      setMsg(`Failed: ${res.error}`);
     }
+    setBusy(false);
   }
 
   return (
@@ -97,12 +96,10 @@ export function SubmissionItem({ submission }: { submission: Submission }) {
         disabled={busy}
         onClick={async () => {
           setBusy(true);
-          try {
-            await reviewSubmissionAction(submission.id);
-            router.refresh();
-          } finally {
-            setBusy(false);
-          }
+          const res = await reviewSubmissionAction(submission.id);
+          if (res.ok) router.refresh();
+          else alert(res.error);
+          setBusy(false);
         }}
         className="shrink-0 rounded-md border border-slate-300 px-2.5 py-1 text-xs font-medium hover:bg-slate-50 disabled:opacity-60"
       >

--- a/agent-ready-plugins-tracker/app/admin/StatusForm.tsx
+++ b/agent-ready-plugins-tracker/app/admin/StatusForm.tsx
@@ -69,15 +69,14 @@ export default function StatusForm({
       notes: notes.trim() || undefined,
       lastVerified: initial.lastVerified ?? "",
     };
-    try {
-      await saveStatusAction(slug, status);
+    const res = await saveStatusAction(slug, status);
+    if (res.ok) {
       setMsg("Saved.");
       router.refresh();
-    } catch {
-      setMsg("Save failed.");
-    } finally {
-      setSaving(false);
+    } else {
+      setMsg(`Save failed: ${res.error}`);
     }
+    setSaving(false);
   }
 
   return (

--- a/agent-ready-plugins-tracker/app/admin/actions.ts
+++ b/agent-ready-plugins-tracker/app/admin/actions.ts
@@ -5,25 +5,45 @@ import { isAdmin } from "@/lib/admin-auth";
 import { setAIStatus, upsertPlugin, markSubmissionReviewed } from "@/lib/db";
 import type { AIStatus, Plugin } from "@/lib/types";
 
-async function assertAdmin() {
-  if (!(await isAdmin())) throw new Error("Unauthorized");
+export type ActionResult = { ok: true } | { ok: false; error: string };
+
+function toMessage(e: unknown): string {
+  if (e && typeof e === "object" && "message" in e) {
+    return String((e as { message: unknown }).message);
+  }
+  return typeof e === "string" ? e : "Unknown error";
 }
 
-export async function saveStatusAction(slug: string, status: AIStatus): Promise<void> {
-  await assertAdmin();
-  await setAIStatus(slug, { ...status, lastVerified: new Date().toISOString().slice(0, 10) });
-  revalidatePath("/admin");
-  revalidatePath(`/admin/plugins/${slug}`);
+export async function saveStatusAction(slug: string, status: AIStatus): Promise<ActionResult> {
+  if (!(await isAdmin())) return { ok: false, error: "Not signed in as admin (try /admin/login again)." };
+  try {
+    await setAIStatus(slug, { ...status, lastVerified: new Date().toISOString().slice(0, 10) });
+    revalidatePath("/admin");
+    revalidatePath(`/admin/plugins/${slug}`);
+    return { ok: true };
+  } catch (e) {
+    return { ok: false, error: toMessage(e) };
+  }
 }
 
-export async function addPluginAction(plugin: Plugin): Promise<void> {
-  await assertAdmin();
-  await upsertPlugin(plugin);
-  revalidatePath("/admin");
+export async function addPluginAction(plugin: Plugin): Promise<ActionResult> {
+  if (!(await isAdmin())) return { ok: false, error: "Not signed in as admin (try /admin/login again)." };
+  try {
+    await upsertPlugin(plugin);
+    revalidatePath("/admin");
+    return { ok: true };
+  } catch (e) {
+    return { ok: false, error: toMessage(e) };
+  }
 }
 
-export async function reviewSubmissionAction(id: string): Promise<void> {
-  await assertAdmin();
-  await markSubmissionReviewed(id);
-  revalidatePath("/admin");
+export async function reviewSubmissionAction(id: string): Promise<ActionResult> {
+  if (!(await isAdmin())) return { ok: false, error: "Not signed in as admin (try /admin/login again)." };
+  try {
+    await markSubmissionReviewed(id);
+    revalidatePath("/admin");
+    return { ok: true };
+  } catch (e) {
+    return { ok: false, error: toMessage(e) };
+  }
 }


### PR DESCRIPTION
The admin dashboard showed a generic "Failed to add plugin" because Next.js redacts thrown server-action error messages in production. Server actions now return a typed `{ ok, error }` result and the UI shows the real message (e.g. "Supabase not configured", PostgREST `relation "plugins" does not exist`, or an RLS violation) — so the actual cause of a failure is visible.

No behavior change on success. `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)