### PR TITLE
feat(tracker): AI status check via Vercel AI Gateway (cron + manual)

### DIFF
--- a/agent-ready-plugins-tracker/.env.example
+++ b/agent-ready-plugins-tracker/.env.example
@@ -18,3 +18,14 @@ ADMIN_SECRET=
 # Defaults to the agent-connector-for-wp repo's stable pack-index release asset:
 #   https://github.com/soflyy/agent-connector-for-wp/releases/download/pack-index/index.json
 PACK_INDEX_URL=
+
+# AI status check (Vercel AI Gateway). Researches each plugin's AI-ability status
+# via live web search and writes typed results to the DB.
+# AI_GATEWAY_API_KEY — required to run the check (Vercel → AI Gateway).
+# CRON_SECRET — required so the daily cron can authenticate (Vercel sends it as a Bearer token).
+# AI_RESEARCH_MODEL — optional, defaults to perplexity/sonar (live web search + citations).
+# AI_CHECK_BATCH — optional, plugins re-checked per cron run (default 25, stalest first).
+AI_GATEWAY_API_KEY=
+CRON_SECRET=
+AI_RESEARCH_MODEL=
+AI_CHECK_BATCH=

--- a/agent-ready-plugins-tracker/README.md
+++ b/agent-ready-plugins-tracker/README.md
@@ -67,11 +67,35 @@ you can:
 Writes go through server actions that re-check the admin session; the older
 `PUT /api/admin/status` (bearer-token) endpoint still works for scripted updates.
 
+## AI status check (Vercel AI Gateway)
+
+The directory can keep itself current by researching each plugin's AI-ability status with
+live web search and writing typed results to the DB.
+
+- **How:** [`lib/ai-research.ts`](lib/ai-research.ts) calls a search-capable model through the
+  **Vercel AI Gateway** (default `perplexity/sonar` — live web search + citations) with the AI
+  SDK's `generateObject` + a Zod schema, returning `{ level, officialSince, officialDocsUrl,
+  abilities, unofficialPlugins, notes, sources, confidence }`.
+- **Apply policy:** results auto-apply to a plugin's status **except** statuses an admin edited
+  by hand (`source = manual`) — those keep the human edit, and the AI result is stored as a
+  `suggestion` you can review and "Load into form" on the edit page.
+- **Schedule:** a daily Vercel **cron** ([`vercel.json`](vercel.json)) hits
+  `GET /api/admin/ai-check` (authorized by `CRON_SECRET`) and re-checks the
+  least-recently-checked `AI_CHECK_BATCH` plugins (default 25), cycling through the whole
+  directory over days.
+- **Manual:** the admin dashboard has **Run AI check now** (batch) and per-plugin
+  **Re-check (AI)** buttons, which call `POST /api/admin/ai-check`.
+
+Required env: `AI_GATEWAY_API_KEY`, `CRON_SECRET`. Optional: `AI_RESEARCH_MODEL`,
+`AI_CHECK_BATCH`. Perplexity web search via the gateway bills ~\$5 / 1,000 searches plus tokens.
+
 ## Database
 
 Run [`supabase/migration.sql`](supabase/migration.sql) against your Supabase project to
-create the schema. Seed data lives in [`data/`](data/); the seed and admin endpoints under
-[`app/api/`](app/) are guarded by `SEED_SECRET` / `ADMIN_SECRET`.
+create the schema (existing databases: also run
+[`supabase/migration-ai-check.sql`](supabase/migration-ai-check.sql) for the AI-check columns).
+Seed data lives in [`data/`](data/); the seed and admin endpoints under [`app/api/`](app/) are
+guarded by `SEED_SECRET` / `ADMIN_SECRET`.
 
 ## Deployment (Vercel)
 

--- a/agent-ready-plugins-tracker/app/admin/AdminClient.tsx
+++ b/agent-ready-plugins-tracker/app/admin/AdminClient.tsx
@@ -8,6 +8,77 @@ import { addPluginAction, reviewSubmissionAction } from "./actions";
 const input =
   "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-wp-blue focus:outline-none focus:ring-1 focus:ring-wp-blue";
 
+async function postAiCheck(body: object): Promise<{ ok: boolean; message: string }> {
+  try {
+    const res = await fetch("/api/admin/ai-check", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    const data = await res.json();
+    if (!res.ok) return { ok: false, message: data?.error || `HTTP ${res.status}` };
+    if (typeof data.checked === "number") {
+      const applied = (data.results || []).filter((r: { applied?: boolean }) => r.applied).length;
+      const failed = (data.results || []).filter((r: { ok?: boolean }) => r.ok === false).length;
+      return { ok: true, message: `Checked ${data.checked}; applied ${applied}${failed ? `; ${failed} failed` : ""}.` };
+    }
+    if (data.ok === false) return { ok: false, message: data.error || "Check failed." };
+    return { ok: true, message: `${data.level ?? "done"}${data.applied === false ? " (kept manual edit)" : ""}.` };
+  } catch (e) {
+    return { ok: false, message: e instanceof Error ? e.message : "Request failed" };
+  }
+}
+
+export function AiCheckButton({ slug }: { slug: string }) {
+  const router = useRouter();
+  const [busy, setBusy] = useState(false);
+  const [msg, setMsg] = useState("");
+  return (
+    <span className="inline-flex items-center gap-2">
+      <button
+        disabled={busy}
+        onClick={async () => {
+          setBusy(true);
+          setMsg("");
+          const r = await postAiCheck({ slug });
+          setMsg(r.message);
+          if (r.ok) router.refresh();
+          setBusy(false);
+        }}
+        className="rounded-md border border-slate-300 px-2.5 py-1 text-xs font-medium hover:bg-slate-50 disabled:opacity-60"
+      >
+        {busy ? "Checking…" : "Re-check (AI)"}
+      </button>
+      {msg && <span className="text-xs text-slate-500">{msg}</span>}
+    </span>
+  );
+}
+
+export function AiCheckAllButton() {
+  const router = useRouter();
+  const [busy, setBusy] = useState(false);
+  const [msg, setMsg] = useState("");
+  return (
+    <div className="flex items-center gap-3">
+      <button
+        disabled={busy}
+        onClick={async () => {
+          setBusy(true);
+          setMsg("");
+          const r = await postAiCheck({ all: true });
+          setMsg(r.message);
+          if (r.ok) router.refresh();
+          setBusy(false);
+        }}
+        className="rounded-lg bg-wp-blue px-4 py-2 text-sm font-semibold text-white hover:bg-wp-blue-dark disabled:opacity-60"
+      >
+        {busy ? "Checking…" : "Run AI check now"}
+      </button>
+      {msg && <span className="text-sm text-slate-600">{msg}</span>}
+    </div>
+  );
+}
+
 export function LogoutButton() {
   const router = useRouter();
   return (

--- a/agent-ready-plugins-tracker/app/admin/StatusForm.tsx
+++ b/agent-ready-plugins-tracker/app/admin/StatusForm.tsx
@@ -44,6 +44,19 @@ export default function StatusForm({
     setUnofficial((rows) => rows.filter((_, idx) => idx !== i));
   }
 
+  function loadSuggestion() {
+    const s = initial.suggestion;
+    if (!s) return;
+    setLevel(s.level);
+    setOfficialSince(s.officialSince ?? "");
+    setOfficialDocsUrl(s.officialDocsUrl ?? "");
+    setAbilitiesCount(s.abilitiesCount != null ? String(s.abilitiesCount) : "");
+    setAbilitiesText((s.abilities ?? []).join("\n"));
+    setNotes(s.notes ?? "");
+    setUnofficial(s.unofficialPlugins ?? []);
+    setMsg("Loaded AI suggestion into the form — review and Save.");
+  }
+
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     setSaving(true);
@@ -88,6 +101,43 @@ export default function StatusForm({
       <p className="mb-6 text-sm text-slate-500">
         <code>{slug}</code> — AI ability status
       </p>
+
+      {initial.suggestion && (
+        <div className="mb-6 rounded-lg border border-blue-200 bg-blue-50 p-4 text-sm">
+          <div className="flex items-center justify-between">
+            <strong className="text-slate-900">AI suggestion</strong>
+            <button
+              type="button"
+              onClick={loadSuggestion}
+              className="rounded-md border border-blue-300 bg-white px-2.5 py-1 text-xs font-medium hover:bg-blue-100"
+            >
+              Load into form
+            </button>
+          </div>
+          <p className="mt-1 text-slate-600">
+            level <strong>{initial.suggestion.level}</strong> · confidence {initial.suggestion.confidence}
+            {initial.suggestion.checkedAt ? ` · checked ${initial.suggestion.checkedAt.slice(0, 10)}` : ""}
+          </p>
+          {initial.suggestion.notes && <p className="mt-1 text-slate-600">{initial.suggestion.notes}</p>}
+          {initial.suggestion.sources?.length > 0 && (
+            <ul className="mt-2 list-disc pl-5 text-xs text-slate-500">
+              {initial.suggestion.sources.slice(0, 6).map((u, i) => (
+                <li key={i}>
+                  <a href={u} target="_blank" rel="noopener noreferrer" className="break-all text-wp-blue hover:underline">
+                    {u}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          )}
+          {initial.source === "manual" && (
+            <p className="mt-2 text-xs text-amber-700">
+              This status is manually curated, so the daily AI check won&apos;t overwrite it. Use “Load into form”
+              to apply the suggestion, then Save.
+            </p>
+          )}
+        </div>
+      )}
 
       <form onSubmit={handleSubmit} className="space-y-5">
         <div>

--- a/agent-ready-plugins-tracker/app/admin/page.tsx
+++ b/agent-ready-plugins-tracker/app/admin/page.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import { requireAdmin } from "@/lib/admin-auth";
 import { getAllPluginsWithStatus, getSubmissions } from "@/lib/db";
-import { AddPluginForm, LogoutButton, SubmissionItem } from "./AdminClient";
+import { AddPluginForm, AiCheckAllButton, AiCheckButton, LogoutButton, SubmissionItem } from "./AdminClient";
 
 export const dynamic = "force-dynamic";
 
@@ -26,16 +26,25 @@ export default async function AdminPage() {
       </div>
 
       <section className="mb-10">
-        <h2 className="mb-3 text-lg font-semibold text-slate-900">
-          Plugins <span className="text-sm font-normal text-slate-400">({plugins.length})</span>
-        </h2>
+        <div className="mb-3 flex items-center justify-between">
+          <h2 className="text-lg font-semibold text-slate-900">
+            Plugins <span className="text-sm font-normal text-slate-400">({plugins.length})</span>
+          </h2>
+          <AiCheckAllButton />
+        </div>
+        <p className="mb-3 text-sm text-slate-500">
+          The AI check researches each plugin&apos;s current AI-ability status via web search and writes the
+          result here. It runs daily (least-recently-checked first) and overwrites everything except statuses
+          you&apos;ve edited by hand (those keep your edits; the AI result is saved as a suggestion).
+        </p>
         <div className="overflow-hidden rounded-xl border border-slate-200">
           <table className="w-full text-sm">
             <thead className="bg-slate-50 text-left text-slate-500">
               <tr>
                 <th className="px-4 py-2 font-medium">Plugin</th>
                 <th className="px-4 py-2 font-medium">Level</th>
-                <th className="px-4 py-2 font-medium">Third-party</th>
+                <th className="px-4 py-2 font-medium">Source</th>
+                <th className="px-4 py-2 font-medium">Checked</th>
                 <th className="px-4 py-2"></th>
               </tr>
             </thead>
@@ -51,17 +60,25 @@ export default async function AdminPage() {
                       {p.aiStatus.level}
                     </span>
                   </td>
-                  <td className="px-4 py-2 text-slate-500">{p.aiStatus.unofficialPlugins.length || "—"}</td>
-                  <td className="px-4 py-2 text-right">
-                    <Link href={`/admin/plugins/${p.slug}`} className="text-wp-blue hover:underline">
-                      Edit
-                    </Link>
+                  <td className="px-4 py-2 text-slate-500">
+                    {p.aiStatus.source === "manual" ? "✎ manual" : p.aiStatus.source === "ai" ? "AI" : "—"}
+                  </td>
+                  <td className="px-4 py-2 text-slate-500">
+                    {p.aiStatus.autoCheckedAt ? p.aiStatus.autoCheckedAt.slice(0, 10) : "never"}
+                  </td>
+                  <td className="px-4 py-2">
+                    <div className="flex items-center justify-end gap-3">
+                      <AiCheckButton slug={p.slug} />
+                      <Link href={`/admin/plugins/${p.slug}`} className="text-wp-blue hover:underline">
+                        Edit
+                      </Link>
+                    </div>
                   </td>
                 </tr>
               ))}
               {plugins.length === 0 && (
                 <tr>
-                  <td colSpan={4} className="px-4 py-6 text-center text-slate-400">
+                  <td colSpan={5} className="px-4 py-6 text-center text-slate-400">
                     No plugins yet. Add one below.
                   </td>
                 </tr>

--- a/agent-ready-plugins-tracker/app/api/admin/ai-check/route.ts
+++ b/agent-ready-plugins-tracker/app/api/admin/ai-check/route.ts
@@ -1,0 +1,45 @@
+import { NextRequest, NextResponse } from "next/server";
+import { isAdmin } from "@/lib/admin-auth";
+import { runBatch, checkBySlug } from "@/lib/ai-check";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 300; // allow long batches (Vercel Pro)
+
+const DEFAULT_BATCH = Number(process.env.AI_CHECK_BATCH || "25");
+
+function cronAuthorized(req: NextRequest): boolean {
+  const secret = process.env.CRON_SECRET;
+  return !!secret && req.headers.get("authorization") === `Bearer ${secret}`;
+}
+
+// Daily cron entry (Vercel sends Authorization: Bearer CRON_SECRET). Also usable
+// by a signed-in admin. Re-checks the least-recently-checked plugins, capped.
+export async function GET(req: NextRequest) {
+  if (!cronAuthorized(req) && !(await isAdmin())) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const results = await runBatch(DEFAULT_BATCH);
+  return NextResponse.json({ checked: results.length, results });
+}
+
+// Manual entry from the admin dashboard: { slug } for one, { all: true } for a batch.
+export async function POST(req: NextRequest) {
+  if (!(await isAdmin())) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  let body: { slug?: string; all?: boolean } = {};
+  try {
+    body = await req.json();
+  } catch {
+    // empty body is fine
+  }
+  if (body.all) {
+    const results = await runBatch(DEFAULT_BATCH);
+    return NextResponse.json({ checked: results.length, results });
+  }
+  if (!body.slug) {
+    return NextResponse.json({ error: "slug or all required" }, { status: 400 });
+  }
+  const result = await checkBySlug(body.slug);
+  return NextResponse.json(result);
+}

--- a/agent-ready-plugins-tracker/lib/ai-check.ts
+++ b/agent-ready-plugins-tracker/lib/ai-check.ts
@@ -1,0 +1,45 @@
+import { researchPluginStatus } from "./ai-research";
+import { applyAiResult, getPluginsToCheck, getPlugin } from "./db";
+
+export interface CheckOutcome {
+  slug: string;
+  ok: boolean;
+  applied?: boolean;
+  level?: string;
+  confidence?: string;
+  error?: string;
+}
+
+/** Research one plugin and apply the result (respecting manual locks). */
+export async function checkOne(slug: string, name: string): Promise<CheckOutcome> {
+  try {
+    const suggestion = await researchPluginStatus(slug, name);
+    const { applied } = await applyAiResult(slug, suggestion);
+    return { slug, ok: true, applied, level: suggestion.level, confidence: suggestion.confidence };
+  } catch (e) {
+    return { slug, ok: false, error: e instanceof Error ? e.message : String(e) };
+  }
+}
+
+/** Look up a plugin's name and check it. */
+export async function checkBySlug(slug: string): Promise<CheckOutcome> {
+  const plugin = await getPlugin(slug);
+  if (!plugin) return { slug, ok: false, error: "Plugin not found" };
+  return checkOne(slug, plugin.name);
+}
+
+/** Check up to `limit` least-recently-checked plugins, bounded concurrency. */
+export async function runBatch(limit: number): Promise<CheckOutcome[]> {
+  const targets = await getPluginsToCheck(limit);
+  const out: CheckOutcome[] = [];
+  const CONCURRENCY = 3;
+  let next = 0;
+  async function worker() {
+    while (next < targets.length) {
+      const t = targets[next++];
+      out.push(await checkOne(t.slug, t.name));
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(CONCURRENCY, targets.length) }, worker));
+  return out;
+}

--- a/agent-ready-plugins-tracker/lib/ai-research.ts
+++ b/agent-ready-plugins-tracker/lib/ai-research.ts
@@ -1,0 +1,77 @@
+import { generateObject } from "ai";
+import { z } from "zod";
+import type { AISuggestion } from "./types";
+
+// Model routed through the Vercel AI Gateway (uses AI_GATEWAY_API_KEY). Perplexity
+// Sonar performs live web search with citations, so a single call both researches
+// and returns structured output. Override with AI_RESEARCH_MODEL.
+const MODEL = process.env.AI_RESEARCH_MODEL || "perplexity/sonar";
+
+const schema = z.object({
+  level: z
+    .enum(["official", "unofficial", "coming_soon", "none"])
+    .describe(
+      "official = the plugin ships its own AI abilities (e.g. via the WordPress Abilities API / MCP). " +
+        "unofficial = no first-party support, but a third-party plugin/extension adds AI abilities or an MCP server for it. " +
+        "coming_soon = official support publicly announced but not yet shipped. none = no known AI ability support."
+    ),
+  officialSince: z.string().optional().describe("Plugin version that introduced official AI abilities, if official."),
+  officialDocsUrl: z.string().optional().describe("URL to official docs/announcement/roadmap."),
+  abilitiesCount: z.number().int().optional().describe("Approximate number of official abilities, if known."),
+  abilities: z.array(z.string()).describe("Names of official abilities, if any (empty if none)."),
+  unofficialPlugins: z
+    .array(
+      z.object({
+        name: z.string(),
+        pluginUrl: z.string().describe("URL to the third-party extension / MCP server."),
+        description: z.string(),
+        author: z.string(),
+        authorUrl: z.string().optional(),
+      })
+    )
+    .describe("Third-party (unofficial) extensions that add AI abilities or an MCP server for this plugin."),
+  notes: z.string().optional().describe("One or two sentences of context."),
+  sources: z.array(z.string()).describe("URLs of the sources used to determine this status."),
+  confidence: z.enum(["high", "medium", "low"]),
+});
+
+/**
+ * Research a WordPress plugin's current AI-ability status via live web search,
+ * returning typed, citation-backed data. Throws if the gateway isn't configured
+ * or the model call fails.
+ */
+export async function researchPluginStatus(slug: string, name: string): Promise<AISuggestion> {
+  if (!process.env.AI_GATEWAY_API_KEY) {
+    throw new Error("AI_GATEWAY_API_KEY is not set");
+  }
+
+  const prompt = `You are researching whether the WordPress plugin "${name}" (wordpress.org slug "${slug}") supports AI "abilities" as of today.
+
+Determine, using current web sources:
+- Does the plugin ship FIRST-PARTY AI abilities (e.g. via the WordPress Abilities API introduced in WP 6.9, the WordPress MCP Adapter, or its own MCP server)? If so, which version added them, link the docs, and list the abilities.
+- Is there official support only ANNOUNCED but not yet released (coming_soon)?
+- Otherwise, are there THIRD-PARTY/unofficial plugins or MCP servers that add AI abilities for this plugin? List each with its URL and author.
+- If you find nothing credible, use level "none".
+
+Be conservative: only claim "official" with a credible first-party source. Always include the source URLs you relied on, and a confidence level.`;
+
+  const { object } = await generateObject({
+    model: MODEL,
+    schema,
+    prompt,
+    temperature: 0,
+  });
+
+  return {
+    level: object.level,
+    officialSince: object.officialSince,
+    officialDocsUrl: object.officialDocsUrl,
+    abilitiesCount: object.abilitiesCount,
+    abilities: object.abilities ?? [],
+    unofficialPlugins: object.unofficialPlugins ?? [],
+    notes: object.notes,
+    sources: object.sources ?? [],
+    confidence: object.confidence,
+    checkedAt: new Date().toISOString(),
+  };
+}

--- a/agent-ready-plugins-tracker/lib/db.ts
+++ b/agent-ready-plugins-tracker/lib/db.ts
@@ -1,5 +1,5 @@
 import { createClient } from "@supabase/supabase-js";
-import type { AIStatus, Plugin, PluginWithStatus, Submission } from "./types";
+import type { AISuggestion, AIStatus, Plugin, PluginWithStatus, Submission } from "./types";
 
 function getClient() {
   const url = process.env.SUPABASE_URL;
@@ -86,8 +86,67 @@ export async function getStatusesForSlugs(slugs: string[]): Promise<Record<strin
 export async function setAIStatus(slug: string, status: AIStatus): Promise<void> {
   const supabase = getClient();
   if (!supabase) throw new Error("Supabase not configured");
-  const { error } = await supabase.from("ai_statuses").upsert(statusToRow(slug, status));
+  // A manual save marks the row as human-curated so the AI job won't overwrite it.
+  const { error } = await supabase.from("ai_statuses").upsert(statusToRow(slug, { ...status, source: "manual" }));
   if (error) throw error;
+}
+
+/**
+ * Plugins to AI-check, least-recently-checked first (never-checked first), capped.
+ * Returns minimal {slug, name} for the research step.
+ */
+export async function getPluginsToCheck(limit: number): Promise<Array<{ slug: string; name: string }>> {
+  const supabase = getClient();
+  if (!supabase) return [];
+  const { data } = await supabase.from("plugins").select("slug, name, ai_statuses(auto_checked_at)");
+  if (!data) return [];
+  const checkedAt = (row: { ai_statuses?: unknown }): string => {
+    const s = row.ai_statuses;
+    const rec = Array.isArray(s) ? s[0] : s;
+    return (rec as { auto_checked_at?: string } | null)?.auto_checked_at ?? "";
+  };
+  return [...data]
+    .sort((a, b) => checkedAt(a).localeCompare(checkedAt(b))) // "" (never) sorts first
+    .slice(0, limit)
+    .map((r) => ({ slug: r.slug as string, name: r.name as string }));
+}
+
+/**
+ * Apply an AI research result. Always records auto_checked_at + the suggestion.
+ * Overwrites the live status UNLESS it was manually curated (source = "manual"),
+ * in which case the live fields are left intact and the suggestion is kept for review.
+ * Returns whether the live status was applied.
+ */
+export async function applyAiResult(slug: string, suggestion: AISuggestion): Promise<{ applied: boolean }> {
+  const supabase = getClient();
+  if (!supabase) throw new Error("Supabase not configured");
+
+  const { data: current } = await supabase.from("ai_statuses").select("source").eq("slug", slug).maybeSingle();
+  const locked = current?.source === "manual";
+
+  const payload: Record<string, unknown> = {
+    slug,
+    auto_checked_at: suggestion.checkedAt,
+    suggestion,
+  };
+  if (!locked) {
+    payload.level = suggestion.level;
+    payload.official_since = suggestion.officialSince ?? null;
+    payload.official_docs_url = suggestion.officialDocsUrl ?? null;
+    payload.abilities_count = suggestion.abilitiesCount ?? null;
+    payload.abilities = suggestion.abilities ?? null;
+    payload.unofficial_plugins = suggestion.unofficialPlugins ?? [];
+    payload.notes = suggestion.notes ?? null;
+    payload.sources = suggestion.sources ?? null;
+    payload.confidence = suggestion.confidence ?? null;
+    payload.source = "ai";
+    payload.last_verified = suggestion.checkedAt.slice(0, 10);
+    payload.updated_at = new Date().toISOString();
+  }
+
+  const { error } = await supabase.from("ai_statuses").upsert(payload);
+  if (error) throw error;
+  return { applied: !locked };
 }
 
 // ---- Submissions ----
@@ -160,9 +219,15 @@ function rowToStatus(row: any): AIStatus {
     unofficialPlugins: row.unofficial_plugins ?? [],
     notes: row.notes ?? undefined,
     lastVerified: row.last_verified ?? "unknown",
+    sources: row.sources ?? undefined,
+    confidence: row.confidence ?? undefined,
+    source: row.source ?? undefined,
+    autoCheckedAt: row.auto_checked_at ?? undefined,
+    suggestion: row.suggestion ?? null,
   };
 }
 
+// The live status fields written by a manual admin save (marks source = manual).
 function statusToRow(slug: string, status: AIStatus) {
   return {
     slug,
@@ -174,6 +239,9 @@ function statusToRow(slug: string, status: AIStatus) {
     unofficial_plugins: status.unofficialPlugins,
     notes: status.notes ?? null,
     last_verified: status.lastVerified,
+    sources: status.sources ?? null,
+    confidence: status.confidence ?? null,
+    source: status.source ?? "manual",
     updated_at: new Date().toISOString(),
   };
 }

--- a/agent-ready-plugins-tracker/lib/types.ts
+++ b/agent-ready-plugins-tracker/lib/types.ts
@@ -41,6 +41,9 @@ export interface UnofficialPlugin {
   authorUrl?: string;
 }
 
+/** Who last set the live status: a human admin, or the AI research job. */
+export type AIStatusSource = "manual" | "ai";
+
 export interface AIStatus {
   level: AIStatusLevel;
   /** Plugin version that added official AI abilities */
@@ -55,6 +58,30 @@ export interface AIStatus {
   notes?: string;
   /** ISO 8601 date this status was last verified */
   lastVerified: string;
+  /** Source-evidence URLs backing this status (from the AI check). */
+  sources?: string[];
+  /** AI's confidence in this status: "high" | "medium" | "low". */
+  confidence?: string;
+  /** Whether the live status was last set manually or by the AI job. */
+  source?: AIStatusSource;
+  /** ISO timestamp of the most recent AI check (regardless of whether applied). */
+  autoCheckedAt?: string;
+  /** Latest AI result, kept even when not applied (manual-locked plugins). */
+  suggestion?: AISuggestion | null;
+}
+
+/** A structured AI research result for a plugin's AI-ability status. */
+export interface AISuggestion {
+  level: AIStatusLevel;
+  officialSince?: string;
+  officialDocsUrl?: string;
+  abilitiesCount?: number;
+  abilities?: string[];
+  unofficialPlugins: UnofficialPlugin[];
+  notes?: string;
+  sources: string[];
+  confidence: string;
+  checkedAt: string;
 }
 
 export interface Plugin {

--- a/agent-ready-plugins-tracker/package-lock.json
+++ b/agent-ready-plugins-tracker/package-lock.json
@@ -9,10 +9,12 @@
       "version": "0.1.0",
       "dependencies": {
         "@supabase/supabase-js": "^2.107.0",
+        "ai": "^6.0.197",
         "autoprefixer": "^10.5.0",
         "next": "^15.3.9",
         "react": "^19.0.0",
-        "react-dom": "^19.0.0"
+        "react-dom": "^19.0.0",
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@types/node": "^20",
@@ -24,6 +26,52 @@
         "tailwindcss": "^3.4.1",
         "tsx": "^4.19.3",
         "typescript": "^5"
+      }
+    },
+    "node_modules/@ai-sdk/gateway": {
+      "version": "3.0.125",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.125.tgz",
+      "integrity": "sha512-tocl7cUDoTpmhZqeW8XVKMMznZQwwQAEunF0VyNKmf64qt8NbMIAEiet/vRMzh7Jr9WcFeb6EZjmhLTP4Qx2Og==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.10",
+        "@ai-sdk/provider-utils": "4.0.27",
+        "@vercel/oidc": "3.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/provider": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.10.tgz",
+      "integrity": "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/provider-utils": {
+      "version": "4.0.27",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.27.tgz",
+      "integrity": "sha512-ubkAJ+xODouwtmN1tYlvTPphH1hPOBfZaEQe8U7skGvFAnIRs9PPpsq57bC2+Ky/MB4yzhd6YOsxTAx9sGpazw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.10",
+        "@standard-schema/spec": "^1.1.0",
+        "eventsource-parser": "^3.0.8"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -1440,6 +1488,15 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -1452,6 +1509,12 @@
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.16.1.tgz",
       "integrity": "sha512-TvZbIpeKqGQQ7X0zSCvPH9riMSFQFSggnfBjFZ1mEoILW+UuXCKwOoPcgjMwiUtRqFZ8jWhPJc4um14vC6I4ag==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "license": "MIT"
     },
     "node_modules/@supabase/auth-js": {
@@ -2210,6 +2273,15 @@
         "win32"
       ]
     },
+    "node_modules/@vercel/oidc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.2.0.tgz",
+      "integrity": "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -2231,6 +2303,24 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ai": {
+      "version": "6.0.197",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.197.tgz",
+      "integrity": "sha512-U3KsjkqwQXGHC0u0VeUDqUaNaBS/uQc7v4Vj92Cjv5lPx5DIyRBQYk4Hipy5vwD9AQKIG8uRvdaN9R+pAvrtcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/gateway": "3.0.125",
+        "@ai-sdk/provider": "3.0.10",
+        "@ai-sdk/provider-utils": "4.0.27",
+        "@opentelemetry/api": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/ajv": {
@@ -3718,6 +3808,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -4712,6 +4811,12 @@
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -6890,6 +6995,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/agent-ready-plugins-tracker/package.json
+++ b/agent-ready-plugins-tracker/package.json
@@ -11,10 +11,12 @@
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.107.0",
+    "ai": "^6.0.197",
     "autoprefixer": "^10.5.0",
     "next": "^15.3.9",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/agent-ready-plugins-tracker/supabase/migration-ai-check.sql
+++ b/agent-ready-plugins-tracker/supabase/migration-ai-check.sql
@@ -1,0 +1,12 @@
+-- AI research check columns for existing databases.
+-- Run once in your Supabase SQL editor (new installs already have these via migration.sql).
+
+alter table ai_statuses
+  add column if not exists sources         text[],
+  add column if not exists confidence      text,
+  add column if not exists source          text not null default 'ai',
+  add column if not exists auto_checked_at  timestamptz,
+  add column if not exists suggestion       jsonb;
+
+-- Order daily checks by least-recently-checked first.
+create index if not exists ai_statuses_auto_checked_at_idx on ai_statuses (auto_checked_at nulls first);

--- a/agent-ready-plugins-tracker/supabase/migration.sql
+++ b/agent-ready-plugins-tracker/supabase/migration.sql
@@ -23,7 +23,13 @@ create table if not exists ai_statuses (
   unofficial_plugins  jsonb not null default '[]'::jsonb,
   notes               text,
   last_verified       text,
-  updated_at          timestamptz not null default now()
+  updated_at          timestamptz not null default now(),
+  -- AI research check (see migration-ai-check.sql for existing databases):
+  sources             text[],                       -- source URLs backing the status
+  confidence          text,                         -- 'high' | 'medium' | 'low'
+  source              text not null default 'ai',   -- 'manual' (curated) | 'ai'
+  auto_checked_at     timestamptz,                  -- last AI check time
+  suggestion          jsonb                         -- latest AI result (kept even when not applied)
 );
 
 create table if not exists submissions (

--- a/agent-ready-plugins-tracker/vercel.json
+++ b/agent-ready-plugins-tracker/vercel.json
@@ -1,0 +1,8 @@
+{
+  "crons": [
+    {
+      "path": "/api/admin/ai-check",
+      "schedule": "0 6 * * *"
+    }
+  ]
+}


### PR DESCRIPTION
Researches each plugin's **current AI-ability status** with live web search and writes typed results to the DB — on a daily cron and on demand.

## How it works
- **Research** — [`lib/ai-research.ts`](agent-ready-plugins-tracker/lib/ai-research.ts): the AI SDK's `generateObject` + a Zod schema, through the **Vercel AI Gateway** (default `perplexity/sonar` = live web search + citations). Returns typed `{ level, officialSince, officialDocsUrl, abilities, unofficialPlugins, notes, sources, confidence }`.
- **Apply policy (per your choice)** — auto-applies to a plugin's status **except** ones an admin edited by hand (`source = 'manual'`); those keep the human edit and the AI result is stored as a `suggestion` you can review + "Load into form" on the edit page.
- **Schedule (stalest-first, capped)** — [`vercel.json`](agent-ready-plugins-tracker/vercel.json) daily cron → `GET /api/admin/ai-check` (authorized by `CRON_SECRET`), re-checking the least-recently-checked `AI_CHECK_BATCH` plugins (default 25), cycling the whole directory over days. `maxDuration = 300`.
- **Manual** — dashboard **Run AI check now** (batch) + per-plugin **Re-check (AI)** → `POST /api/admin/ai-check` (admin-gated).

## Data
New `ai_statuses` columns: `sources`, `confidence`, `source`, `auto_checked_at`, `suggestion` — in [`migration.sql`](agent-ready-plugins-tracker/supabase/migration.sql) and an additive [`migration-ai-check.sql`](agent-ready-plugins-tracker/supabase/migration-ai-check.sql) for the existing DB.

## Setup
- Env: **`AI_GATEWAY_API_KEY`**, **`CRON_SECRET`** (+ optional `AI_RESEARCH_MODEL`, `AI_CHECK_BATCH`).
- Run `migration-ai-check.sql` on the existing Supabase project.
- Cost: Perplexity web search via the gateway ≈ \$5 / 1,000 searches + tokens.

New deps: `ai`, `zod`. Built in an isolated clone so your in-progress `tracker-plugins-home` work was untouched. `tsc` clean; `npm run build` succeeds (`/api/admin/ai-check` dynamic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)