### PR TITLE
feat(tracker): auto-reload PostgREST schema cache on DDL

### DIFF
--- a/agent-ready-plugins-tracker/supabase/migration-ai-check.sql
+++ b/agent-ready-plugins-tracker/supabase/migration-ai-check.sql
@@ -10,3 +10,19 @@ alter table ai_statuses
 
 -- Order daily checks by least-recently-checked first.
 create index if not exists ai_statuses_auto_checked_at_idx on ai_statuses (auto_checked_at nulls first);
+
+-- Auto-reload PostgREST's schema cache on any future schema change, and reload now
+-- to fix the current stale cache (the plugins↔ai_statuses relationship the dashboard
+-- join needs).
+create or replace function public.pgrst_reload_on_ddl()
+  returns event_trigger language plpgsql as $$
+begin
+  notify pgrst, 'reload schema';
+end;
+$$;
+
+drop event trigger if exists pgrst_reload_on_ddl;
+create event trigger pgrst_reload_on_ddl on ddl_command_end
+  execute function public.pgrst_reload_on_ddl();
+
+notify pgrst, 'reload schema';

--- a/agent-ready-plugins-tracker/supabase/migration.sql
+++ b/agent-ready-plugins-tracker/supabase/migration.sql
@@ -31,3 +31,20 @@ create table if not exists ai_statuses (
   auto_checked_at     timestamptz,                  -- last AI check time
   suggestion          jsonb                         -- latest AI result (kept even when not applied)
 );
+
+-- Auto-reload PostgREST's schema cache whenever the schema changes (DDL), so new
+-- tables/columns/relationships are picked up immediately — no manual "Reload schema
+-- cache" needed after a migration. (PostgREST listens on the `pgrst` channel.)
+create or replace function public.pgrst_reload_on_ddl()
+  returns event_trigger language plpgsql as $$
+begin
+  notify pgrst, 'reload schema';
+end;
+$$;
+
+drop event trigger if exists pgrst_reload_on_ddl;
+create event trigger pgrst_reload_on_ddl on ddl_command_end
+  execute function public.pgrst_reload_on_ddl();
+
+-- Reload once now so the changes above are picked up immediately.
+notify pgrst, 'reload schema';


### PR DESCRIPTION
Fixes the dashboard showing 0 plugins after a fresh migration. The joined read (plugins + ai_statuses) needs PostgREST to know the foreign-key relationship, but its schema cache is stale right after `create table` — so the embed fails (PGRST200) while plain reads/writes work.

Adds an event trigger on `ddl_command_end` that runs `NOTIFY pgrst, 'reload schema'`, so the cache auto-refreshes on any future schema change (no manual reload). Added to both `migration.sql` and `migration-ai-check.sql`, each ending with a one-time reload to fix the current state.

No app code change (kept the clean embedded query).

🤖 Generated with [Claude Code](https://claude.com/claude-code)