### PR TITLE
feat(tracker): fold the AC4WP ability pack into third-party abilities

### DIFF
--- a/agent-ready-plugins-tracker/app/admin/StatusForm.tsx
+++ b/agent-ready-plugins-tracker/app/admin/StatusForm.tsx
@@ -15,7 +15,6 @@ export default function StatusForm({ initial }: { initial: Plugin }) {
   const [name, setName] = useState(initial.name);
   const [link, setLink] = useState(initial.link ?? "");
   const [includesAbilities, setIncludesAbilities] = useState(initial.includesAbilities);
-  const [packUrl, setPackUrl] = useState(initial.ac4wpAbilityPackUrl ?? "");
   const [thirdParty, setThirdParty] = useState<ThirdPartyAbility[]>(initial.thirdPartyAbilities ?? []);
   const [saving, setSaving] = useState(false);
   const [msg, setMsg] = useState("");
@@ -47,7 +46,6 @@ export default function StatusForm({ initial }: { initial: Plugin }) {
           pluginSlug: t.pluginSlug.trim(),
           pluginLink: t.pluginLink.trim(),
         })),
-      ac4wpAbilityPackUrl: packUrl.trim() || undefined,
     };
     const res = await savePluginAction(plugin);
     setMsg(res.ok ? "Saved." : `Save failed: ${res.error}`);
@@ -87,23 +85,13 @@ export default function StatusForm({ initial }: { initial: Plugin }) {
         </label>
 
         <div>
-          <label className={labelCls}>Agent Connector ability pack URL</label>
-          <input
-            className={input}
-            value={packUrl}
-            onChange={(e) => setPackUrl(e.target.value)}
-            placeholder="https://github.com/soflyy/agent-connector-for-wp/tree/master/ability-packs/…"
-          />
-          <p className="mt-1 text-xs text-slate-400">Leave blank if there is no pack.</p>
-        </div>
-
-        <div>
           <div className="mb-2 flex items-center justify-between">
             <label className={labelCls + " mb-0"}>3rd-party abilities provided by</label>
             <button type="button" onClick={addRow} className="rounded-md border border-slate-300 px-2.5 py-1 text-xs font-medium hover:bg-slate-50">
               + Add
             </button>
           </div>
+          <p className="mb-2 text-xs text-slate-400">Includes our own Agent Connector ability packs — add them here too.</p>
           <div className="space-y-3">
             {thirdParty.length === 0 && <p className="text-sm text-slate-400">None.</p>}
             {thirdParty.map((t, i) => (

--- a/agent-ready-plugins-tracker/app/admin/page.tsx
+++ b/agent-ready-plugins-tracker/app/admin/page.tsx
@@ -44,7 +44,6 @@ export default async function AdminPage() {
                 <th className="px-4 py-2 font-medium">Plugin</th>
                 <th className="px-4 py-2 font-medium">Official</th>
                 <th className="px-4 py-2 font-medium">3rd-party</th>
-                <th className="px-4 py-2 font-medium">AC4WP pack</th>
                 <th className="px-4 py-2"></th>
               </tr>
             </thead>
@@ -57,7 +56,6 @@ export default async function AdminPage() {
                   </td>
                   <td className="px-4 py-2"><YesNo on={p.includesAbilities} /></td>
                   <td className="px-4 py-2 text-slate-500">{p.thirdPartyAbilities.length || "—"}</td>
-                  <td className="px-4 py-2"><YesNo on={!!p.ac4wpAbilityPackUrl} /></td>
                   <td className="px-4 py-2">
                     <div className="flex items-center justify-end gap-3">
                       <AiCheckButton slug={p.slug} />
@@ -71,7 +69,7 @@ export default async function AdminPage() {
               ))}
               {plugins.length === 0 && (
                 <tr>
-                  <td colSpan={5} className="px-4 py-6 text-center text-slate-400">
+                  <td colSpan={4} className="px-4 py-6 text-center text-slate-400">
                     No plugins yet. Add one below.
                   </td>
                 </tr>

--- a/agent-ready-plugins-tracker/app/api/admin/status/route.ts
+++ b/agent-ready-plugins-tracker/app/api/admin/status/route.ts
@@ -24,7 +24,6 @@ export async function PUT(req: NextRequest) {
     link: plugin.link,
     includesAbilities: !!plugin.includesAbilities,
     thirdPartyAbilities: plugin.thirdPartyAbilities ?? [],
-    ac4wpAbilityPackUrl: plugin.ac4wpAbilityPackUrl,
   });
   return NextResponse.json({ ok: true, slug: plugin.slug });
 }

--- a/agent-ready-plugins-tracker/app/page.tsx
+++ b/agent-ready-plugins-tracker/app/page.tsx
@@ -26,11 +26,10 @@ export default async function HomePage() {
 
       <div className="overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm">
         {/* Header */}
-        <div className="grid grid-cols-[1fr_6rem_6rem_6rem] items-center gap-4 border-b border-slate-200 bg-slate-50 px-5 py-2.5 text-xs font-medium uppercase tracking-wide text-slate-500">
+        <div className="grid grid-cols-[1fr_7rem_7rem] items-center gap-4 border-b border-slate-200 bg-slate-50 px-5 py-2.5 text-xs font-medium uppercase tracking-wide text-slate-500">
           <div>Plugin</div>
           <div className="text-center">Official</div>
           <div className="text-center">3rd-party</div>
-          <div className="text-center">AC4WP pack</div>
         </div>
 
         {/* Rows */}
@@ -39,7 +38,7 @@ export default async function HomePage() {
             <Link
               key={p.slug}
               href={`/plugins/${p.urlSlug}`}
-              className="grid grid-cols-[1fr_6rem_6rem_6rem] items-center gap-4 px-5 py-3.5 transition-colors hover:bg-slate-50"
+              className="grid grid-cols-[1fr_7rem_7rem] items-center gap-4 px-5 py-3.5 transition-colors hover:bg-slate-50"
             >
               <div className="min-w-0">
                 <div className="truncate font-medium text-slate-900">{p.name}</div>
@@ -47,7 +46,6 @@ export default async function HomePage() {
               </div>
               <div className="text-center"><Yes on={p.includesAbilities} /></div>
               <div className="text-center"><Yes on={p.thirdPartyAbilities.length > 0} /></div>
-              <div className="text-center"><Yes on={!!p.ac4wpAbilityPackUrl} /></div>
             </Link>
           ))}
           {plugins.length === 0 && (

--- a/agent-ready-plugins-tracker/app/plugins/[slug]/page.tsx
+++ b/agent-ready-plugins-tracker/app/plugins/[slug]/page.tsx
@@ -64,23 +64,6 @@ export default async function PluginDetailPage({
           <dt className="text-slate-500">Includes abilities</dt>
           <dd><YesNo value={plugin.includesAbilities} /></dd>
         </div>
-        <div className="flex items-center justify-between px-4 py-3">
-          <dt className="text-slate-500">Agent Connector ability pack</dt>
-          <dd>
-            {plugin.ac4wpAbilityPackUrl ? (
-              <a
-                href={plugin.ac4wpAbilityPackUrl}
-                className="font-medium text-wp-blue hover:underline"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                View pack →
-              </a>
-            ) : (
-              <span className="text-slate-400">No</span>
-            )}
-          </dd>
-        </div>
       </dl>
 
       <div className="mt-6">

--- a/agent-ready-plugins-tracker/lib/db.ts
+++ b/agent-ready-plugins-tracker/lib/db.ts
@@ -120,7 +120,6 @@ function rowToPlugin(row: any): Plugin {
     link: row.link ?? undefined,
     includesAbilities: !!row.includes_abilities,
     thirdPartyAbilities: normalizeThirdParty(row.third_party_abilities),
-    ac4wpAbilityPackUrl: row.ac4wp_ability_pack_url ?? undefined,
   };
 }
 
@@ -131,7 +130,6 @@ function pluginToRow(p: Plugin) {
     link: p.link ?? null,
     includes_abilities: p.includesAbilities,
     third_party_abilities: p.thirdPartyAbilities ?? [],
-    ac4wp_ability_pack_url: p.ac4wpAbilityPackUrl ?? null,
     updated_at: new Date().toISOString(),
   };
 }

--- a/agent-ready-plugins-tracker/lib/types.ts
+++ b/agent-ready-plugins-tracker/lib/types.ts
@@ -17,10 +17,8 @@ export interface Plugin {
   link?: string;
   /** Whether the plugin ships its own (official) AI abilities. */
   includesAbilities: boolean;
-  /** Third-party plugins that provide abilities for this plugin. */
+  /** Third-party plugins that provide abilities for this plugin (incl. our own packs). */
   thirdPartyAbilities: ThirdPartyAbility[];
-  /** URL of the Agent Connector ability pack for this plugin, if we publish one. */
-  ac4wpAbilityPackUrl?: string;
 }
 
 /** What the AI research job determines for a plugin. */

--- a/agent-ready-plugins-tracker/supabase/migration.sql
+++ b/agent-ready-plugins-tracker/supabase/migration.sql
@@ -2,8 +2,8 @@
 --
 -- Simplified model: a single `plugins` table. A plugin is identified by its WP
 -- plugin file ("folder/main-file.php"), and we track only: whether it ships its
--- own abilities, which third-party plugins provide abilities for it, and whether
--- we publish an Agent Connector ability pack for it.
+-- own abilities, and which third-party plugins provide abilities for it (our own
+-- Agent Connector ability packs are just entries in that list).
 
 -- Destructive: this redesign changes the `plugins` shape (and the slug now stores
 -- the full plugin file). Old rows can't be migrated cleanly, so we recreate both
@@ -16,8 +16,7 @@ create table if not exists plugins (
   name                    text not null,
   link                    text,                                   -- .org page or commercial plugin page
   includes_abilities      boolean not null default false,         -- plugin ships its own (official) abilities
-  third_party_abilities   jsonb   not null default '[]'::jsonb,   -- [{ name, slug, link }]
-  ac4wp_ability_pack_url  text,                                   -- null = no pack; else the pack's URL
+  third_party_abilities   jsonb   not null default '[]'::jsonb,   -- [{ pluginName, pluginSlug, pluginLink }] (incl. our packs)
   ai_checked_at           timestamptz,                            -- last AI research time (least-recent checked first)
   updated_at              timestamptz not null default now(),
   -- URL-safe slug derived from the plugin file, used for /plugins/<url_slug>:


### PR DESCRIPTION
Our Agent Connector ability pack is itself a third-party plugin that provides abilities, so the dedicated `ac4wp_ability_pack_url` field was redundant — it now lives as a regular entry in `third_party_abilities`.

- Removed `ac4wp_ability_pack_url` from the schema, `Plugin` type, db converters, and `/api/admin/status`.
- Directory + admin tables drop the "AC4WP pack" column (back to Plugin · Official · 3rd-party).
- Detail page drops the ability-pack row; the pack shows up in the 3rd-party list.
- Admin form drops the pack-URL field, with a hint that our own packs go in the 3rd-party list.

The WP plugin's pack **Install** column is unaffected (it reads the GitHub `pack-index` manifest, not this field). Tracker-only — no plugin release.

Optional DB cleanup (the column is now simply ignored if left): `alter table plugins drop column if exists ac4wp_ability_pack_url;`

`tsc` + `npm run build` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)