### PR TITLE
feat(tracker): show full LLM prompt + response on admin AI re-check

### DIFF
--- a/agent-ready-plugins-tracker/app/admin/AdminClient.tsx
+++ b/agent-ready-plugins-tracker/app/admin/AdminClient.tsx
@@ -8,49 +8,125 @@ import { addPluginAction, deletePluginAction } from "./actions";
 const input =
   "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-wp-blue focus:outline-none focus:ring-1 focus:ring-wp-blue";
 
-async function postAiCheck(body: object): Promise<{ ok: boolean; message: string }> {
+interface AiDebug {
+  model?: string;
+  temperature?: number;
+  prompt?: string;
+  request?: unknown;
+  rawResponse?: unknown;
+  object?: unknown;
+  usage?: unknown;
+  finishReason?: string;
+  warnings?: unknown;
+}
+interface CheckData {
+  ok?: boolean;
+  error?: string;
+  includesAbilities?: boolean;
+  thirdPartyCount?: number;
+  debug?: AiDebug;
+}
+
+async function callAiCheck(body: object): Promise<{ httpOk: boolean; data: CheckData }> {
+  const res = await fetch("/api/admin/ai-check", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  const data = await res.json().catch(() => ({}));
+  return { httpOk: res.ok, data };
+}
+
+function pretty(v: unknown): string {
+  if (v === undefined || v === null) return "—";
+  if (typeof v === "string") return v;
   try {
-    const res = await fetch("/api/admin/ai-check", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(body),
-    });
-    const data = await res.json();
-    if (!res.ok) return { ok: false, message: data?.error || `HTTP ${res.status}` };
-    if (typeof data.checked === "number") {
-      const failed = (data.results || []).filter((r: { ok?: boolean }) => r.ok === false).length;
-      return { ok: true, message: `Checked ${data.checked}${failed ? `; ${failed} failed` : ""}.` };
-    }
-    if (data.ok === false) return { ok: false, message: data.error || "Check failed." };
-    const official = data.includesAbilities ? "official" : "no official";
-    return { ok: true, message: `${official}, ${data.thirdPartyCount ?? 0} third-party.` };
-  } catch (e) {
-    return { ok: false, message: e instanceof Error ? e.message : "Request failed" };
+    return JSON.stringify(v, null, 2);
+  } catch {
+    return String(v);
   }
+}
+
+function DebugSection({ title, value }: { title: string; value: unknown }) {
+  return (
+    <div className="mt-4">
+      <h4 className="mb-1 text-xs font-semibold uppercase tracking-wide text-slate-500">{title}</h4>
+      <pre className="max-h-72 overflow-auto whitespace-pre-wrap break-words rounded-lg bg-slate-50 p-3 text-xs font-mono text-slate-700">
+        {pretty(value)}
+      </pre>
+    </div>
+  );
+}
+
+function DebugModal({ slug, data, onClose }: { slug: string; data: CheckData; onClose: () => void }) {
+  const d = data.debug ?? {};
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto bg-black/40 p-4"
+      onClick={onClose}
+    >
+      <div className="my-8 w-full max-w-3xl rounded-xl bg-white p-6 shadow-xl" onClick={(e) => e.stopPropagation()}>
+        <div className="mb-3 flex items-center justify-between">
+          <h3 className="text-lg font-semibold text-slate-900">
+            AI re-check — <code className="text-sm text-slate-500">{slug}</code>
+          </h3>
+          <button onClick={onClose} className="rounded-md border border-slate-300 px-3 py-1 text-sm font-medium hover:bg-slate-50">
+            Close
+          </button>
+        </div>
+
+        {data.ok === false ? (
+          <p className="rounded-lg bg-red-50 px-3 py-2 text-sm text-red-700">Error: {data.error || "unknown"}</p>
+        ) : (
+          <p className="rounded-lg bg-emerald-50 px-3 py-2 text-sm text-emerald-700">
+            Applied: {data.includesAbilities ? "official abilities" : "no official abilities"}, {data.thirdPartyCount ?? 0} third-party.
+          </p>
+        )}
+
+        <p className="mt-4 text-sm text-slate-600">
+          <span className="font-medium">Model:</span> <code>{d.model ?? "—"}</code>
+          {" · "}
+          <span className="font-medium">temperature:</span> {String(d.temperature ?? "—")}
+          {d.finishReason ? <> {" · "} <span className="font-medium">finish:</span> {d.finishReason}</> : null}
+        </p>
+
+        <DebugSection title="Prompt" value={d.prompt} />
+        <DebugSection title="Request sent to provider" value={d.request} />
+        <DebugSection title="Raw response from provider" value={d.rawResponse} />
+        <DebugSection title="Parsed object" value={d.object} />
+        <DebugSection title="Usage" value={d.usage} />
+        {d.warnings ? <DebugSection title="Warnings" value={d.warnings} /> : null}
+      </div>
+    </div>
+  );
 }
 
 export function AiCheckButton({ slug }: { slug: string }) {
   const router = useRouter();
   const [busy, setBusy] = useState(false);
-  const [msg, setMsg] = useState("");
+  const [result, setResult] = useState<CheckData | null>(null);
   return (
-    <span className="inline-flex items-center gap-2">
+    <>
       <button
         disabled={busy}
         onClick={async () => {
           setBusy(true);
-          setMsg("");
-          const r = await postAiCheck({ slug });
-          setMsg(r.message);
-          if (r.ok) router.refresh();
+          try {
+            const { httpOk, data } = await callAiCheck({ slug });
+            const shaped: CheckData = httpOk ? data : { ok: false, error: data?.error || "Request failed", debug: data?.debug };
+            setResult(shaped);
+            if (httpOk && data?.ok) router.refresh();
+          } catch (e) {
+            setResult({ ok: false, error: e instanceof Error ? e.message : "Request failed" });
+          }
           setBusy(false);
         }}
         className="rounded-md border border-slate-300 px-2.5 py-1 text-xs font-medium hover:bg-slate-50 disabled:opacity-60"
       >
         {busy ? "Checking…" : "Re-check (AI)"}
       </button>
-      {msg && <span className="text-xs text-slate-500">{msg}</span>}
-    </span>
+      {result && <DebugModal slug={slug} data={result} onClose={() => setResult(null)} />}
+    </>
   );
 }
 
@@ -65,9 +141,19 @@ export function AiCheckAllButton() {
         onClick={async () => {
           setBusy(true);
           setMsg("");
-          const r = await postAiCheck({ all: true });
-          setMsg(r.message);
-          if (r.ok) router.refresh();
+          try {
+            const { httpOk, data } = await callAiCheck({ all: true });
+            if (!httpOk) {
+              setMsg((data as { error?: string })?.error || "Request failed");
+            } else {
+              const results = (data as unknown as { checked?: number; results?: { ok?: boolean }[] });
+              const failed = (results.results || []).filter((r) => r.ok === false).length;
+              setMsg(`Checked ${results.checked ?? 0}${failed ? `; ${failed} failed` : ""}.`);
+              router.refresh();
+            }
+          } catch (e) {
+            setMsg(e instanceof Error ? e.message : "Request failed");
+          }
           setBusy(false);
         }}
         className="rounded-lg bg-wp-blue px-4 py-2 text-sm font-semibold text-white hover:bg-wp-blue-dark disabled:opacity-60"

--- a/agent-ready-plugins-tracker/lib/ai-check.ts
+++ b/agent-ready-plugins-tracker/lib/ai-check.ts
@@ -1,4 +1,4 @@
-import { researchPlugin } from "./ai-research";
+import { researchPlugin, type ResearchDebug } from "./ai-research";
 import { applyAiResult, getPluginsToCheck, getPlugin } from "./db";
 
 export interface CheckOutcome {
@@ -7,22 +7,28 @@ export interface CheckOutcome {
   includesAbilities?: boolean;
   thirdPartyCount?: number;
   error?: string;
+  /** Full prompt / params / raw request + response for the admin UI. */
+  debug?: ResearchDebug;
 }
 
 /** Research one plugin and apply the result. */
 export async function checkOne(slug: string, name: string): Promise<CheckOutcome> {
-  try {
-    const result = await researchPlugin(slug, name);
-    await applyAiResult(slug, result);
-    return {
-      slug,
-      ok: true,
-      includesAbilities: result.pluginIncludesOfficialAbilities,
-      thirdPartyCount: result.thirdPartyAbilitiesProvidedBy.length,
-    };
-  } catch (e) {
-    return { slug, ok: false, error: e instanceof Error ? e.message : String(e) };
+  const outcome = await researchPlugin(slug, name);
+  if (!outcome.ok) {
+    return { slug, ok: false, error: outcome.error, debug: outcome.debug };
   }
+  try {
+    await applyAiResult(slug, outcome.result);
+  } catch (e) {
+    return { slug, ok: false, error: e instanceof Error ? e.message : String(e), debug: outcome.debug };
+  }
+  return {
+    slug,
+    ok: true,
+    includesAbilities: outcome.result.pluginIncludesOfficialAbilities,
+    thirdPartyCount: outcome.result.thirdPartyAbilitiesProvidedBy.length,
+    debug: outcome.debug,
+  };
 }
 
 /** Look up a plugin's name and check it. */
@@ -41,7 +47,9 @@ export async function runBatch(limit: number): Promise<CheckOutcome[]> {
   async function worker() {
     while (next < targets.length) {
       const t = targets[next++];
-      out.push(await checkOne(t.slug, t.name));
+      // Drop the verbose debug payload from batch results to keep them small.
+      const { debug: _debug, ...rest } = await checkOne(t.slug, t.name);
+      out.push(rest);
     }
   }
   await Promise.all(Array.from({ length: Math.min(CONCURRENCY, targets.length) }, worker));

--- a/agent-ready-plugins-tracker/lib/ai-research.ts
+++ b/agent-ready-plugins-tracker/lib/ai-research.ts
@@ -6,6 +6,7 @@ import type { AIResearchResult } from "./types";
 // Sonar performs live web search with citations, so a single call both researches
 // and returns structured output. Override with AI_RESEARCH_MODEL.
 const MODEL = process.env.AI_RESEARCH_MODEL || "perplexity/sonar";
+const TEMPERATURE = 0;
 
 const schema = z.object({
   pluginIncludesOfficialAbilities: z
@@ -26,34 +27,76 @@ const schema = z.object({
 });
 
 /**
- * Research a WordPress plugin via live web search and determine two things:
- * whether it now ships official abilities, and which third-party plugins provide
- * abilities for it. Throws if the gateway isn't configured or the call fails.
+ * Everything sent to and returned from the LLM for one research call — surfaced
+ * in the admin UI so a re-check is fully inspectable. `request`/`rawResponse`
+ * come straight from the AI SDK (the actual provider HTTP bodies).
  */
-export async function researchPlugin(slug: string, name: string): Promise<AIResearchResult> {
-  if (!process.env.AI_GATEWAY_API_KEY) {
-    throw new Error("AI_GATEWAY_API_KEY is not set");
-  }
+export interface ResearchDebug {
+  model: string;
+  temperature: number;
+  prompt: string;
+  request?: unknown;
+  rawResponse?: unknown;
+  object?: AIResearchResult;
+  usage?: unknown;
+  finishReason?: string;
+  warnings?: unknown;
+}
 
-  const prompt = `You are researching the WordPress plugin "${name}" (slug "${slug}") as of today.
+export type ResearchOutcome =
+  | { ok: true; result: AIResearchResult; debug: ResearchDebug }
+  | { ok: false; error: string; debug: ResearchDebug };
+
+function buildPrompt(slug: string, name: string): string {
+  return `You are researching the WordPress plugin "${name}" (slug "${slug}") as of today.
 
 Determine, using current web sources, exactly two things:
 1. Does the plugin ship its OWN first-party AI abilities (e.g. via the WordPress Abilities API introduced in WP 6.9, the WordPress MCP Adapter, or its own MCP server)? Be conservative — only say true with a credible first-party source. Announced-but-not-shipped support counts as false.
 2. Are there THIRD-PARTY / unofficial plugins or MCP servers that add AI abilities for this plugin? List each with its name, slug, and URL.`;
+}
 
-  const { object } = await generateObject({
-    model: MODEL,
-    schema,
-    prompt,
-    temperature: 0,
-  });
+/**
+ * Research a WordPress plugin via live web search and determine two things:
+ * whether it now ships official abilities, and which third-party plugins provide
+ * abilities for it. Never throws — returns a typed outcome carrying the full
+ * debug payload (prompt, params, raw request + response) for the admin UI.
+ */
+export async function researchPlugin(slug: string, name: string): Promise<ResearchOutcome> {
+  const prompt = buildPrompt(slug, name);
+  const debug: ResearchDebug = { model: MODEL, temperature: TEMPERATURE, prompt };
 
-  return {
-    pluginIncludesOfficialAbilities: object.pluginIncludesOfficialAbilities,
-    thirdPartyAbilitiesProvidedBy: (object.thirdPartyAbilitiesProvidedBy ?? []).map((u) => ({
-      pluginName: u.pluginName,
-      pluginSlug: u.pluginSlug,
-      pluginLink: u.pluginLink,
-    })),
-  };
+  if (!process.env.AI_GATEWAY_API_KEY) {
+    return { ok: false, error: "AI_GATEWAY_API_KEY is not set", debug };
+  }
+
+  try {
+    const gen = await generateObject({ model: MODEL, schema, prompt, temperature: TEMPERATURE });
+    debug.request = gen.request?.body;
+    debug.rawResponse = gen.response?.body;
+    debug.object = gen.object;
+    debug.usage = gen.usage;
+    debug.finishReason = gen.finishReason;
+    debug.warnings = gen.warnings;
+
+    const result: AIResearchResult = {
+      pluginIncludesOfficialAbilities: gen.object.pluginIncludesOfficialAbilities,
+      thirdPartyAbilitiesProvidedBy: (gen.object.thirdPartyAbilitiesProvidedBy ?? []).map((u) => ({
+        pluginName: u.pluginName,
+        pluginSlug: u.pluginSlug,
+        pluginLink: u.pluginLink,
+      })),
+    };
+    return { ok: true, result, debug };
+  } catch (e) {
+    // The AI SDK attaches the raw request/response (and the model's text, when it
+    // returned something unparseable) to the thrown error — surface it.
+    const err = e as { request?: { body?: unknown }; response?: { body?: unknown }; text?: unknown; cause?: { message?: string } };
+    debug.request = err?.request?.body ?? debug.request;
+    debug.rawResponse = err?.response?.body ?? err?.text ?? null;
+    return {
+      ok: false,
+      error: e instanceof Error ? e.message : String(e),
+      debug,
+    };
+  }
 }


### PR DESCRIPTION
Clicking **Re-check (AI)** on `/admin` now opens a modal showing everything about the LLM call:

- **Model** id and **temperature**
- The exact **prompt**
- The raw **request body** sent to the provider
- The raw **provider response**
- The **parsed object** and **token usage**

The debug payload is captured even when the call fails (so you can inspect the raw response on errors), and is stripped from the daily batch results to keep them small. Tracker-only — no plugin release.

`tsc` + `npm run build` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)