### PR TITLE
feat(tracker): public AI-moderated plugin submission page

### DIFF
--- a/agent-ready-plugins-tracker/.env.example
+++ b/agent-ready-plugins-tracker/.env.example
@@ -14,6 +14,14 @@ SUPABASE_SERVICE_ROLE_KEY=
 SEED_SECRET=
 ADMIN_SECRET=
 
+# Cloudflare Turnstile — bot protection on the public /submit form.
+# Create a widget at Cloudflare → Turnstile. If unset, the form works but bot
+# verification is skipped (intended for local dev only).
+# NEXT_PUBLIC_TURNSTILE_SITE_KEY — the widget site key (public, sent to the browser).
+# TURNSTILE_SECRET_KEY — the secret used for server-side verification.
+NEXT_PUBLIC_TURNSTILE_SITE_KEY=
+TURNSTILE_SECRET_KEY=
+
 # Ability-pack manifest source for /api/ability-packs/match (optional).
 # Defaults to the agent-connector-for-wp repo's stable pack-index release asset:
 #   https://github.com/soflyy/agent-connector-for-wp/releases/download/pack-index/index.json

--- a/agent-ready-plugins-tracker/app/api/submit/route.ts
+++ b/agent-ready-plugins-tracker/app/api/submit/route.ts
@@ -1,0 +1,67 @@
+import { NextRequest, NextResponse } from "next/server";
+import { verifyTurnstile } from "@/lib/turnstile";
+import { checkPluginUrl } from "@/lib/url-check";
+import { moderateSubmission } from "@/lib/moderation";
+import { pluginExists, getPluginByUrlSlug, upsertPlugin, folderSlug } from "@/lib/db";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 60; // AI moderation can take a few seconds
+
+const MAX_LEN = 100;
+
+function bad(error: string, status = 400) {
+  return NextResponse.json({ ok: false, error }, { status });
+}
+
+// Public endpoint (see middleware PUBLIC_PATHS). Anyone can submit a plugin; it is
+// auto-moderated by AI and added to the directory only if approved. Checks run
+// cheapest-first: bot check → length sanity → duplicate → URL reachable → AI.
+export async function POST(req: NextRequest) {
+  let body: { name?: string; slug?: string; link?: string; turnstileToken?: string };
+  try {
+    body = await req.json();
+  } catch {
+    return bad("Invalid request.");
+  }
+
+  const name = String(body?.name ?? "").trim();
+  const slug = String(body?.slug ?? "").trim();
+  const link = String(body?.link ?? "").trim();
+
+  // 1. Bot check (Cloudflare Turnstile).
+  const ip = req.headers.get("x-forwarded-for")?.split(",")[0]?.trim();
+  if (!(await verifyTurnstile(body?.turnstileToken, ip))) {
+    return bad("Bot check failed — please retry.");
+  }
+
+  // 2. Length sanity.
+  if (!name || !slug || !link) return bad("Name, slug, and link are all required.");
+  if (name.length >= MAX_LEN) return bad("Name must be under 100 characters.");
+  if (slug.length >= MAX_LEN) return bad("Slug must be under 100 characters.");
+
+  // 3. Duplicate check (exact slug, or same URL slug already listed).
+  if ((await pluginExists(slug)) || (await getPluginByUrlSlug(folderSlug(slug)))) {
+    return bad("That plugin is already in the directory.", 409);
+  }
+
+  // 4. URL is a reachable, non-404 site.
+  const urlCheck = await checkPluginUrl(link);
+  if (!urlCheck.ok) {
+    return bad(urlCheck.error ?? "The plugin link doesn't resolve to a working site.");
+  }
+
+  // 5. AI moderation — is this a real, listable WordPress plugin?
+  const verdict = await moderateSubmission({ name, slug, link });
+  if (!verdict.approved) {
+    return NextResponse.json({ ok: false, approved: false, error: `Not approved: ${verdict.reason}` });
+  }
+
+  // Approved — add it. The daily AI check fills in abilities later.
+  try {
+    await upsertPlugin({ slug, name, link, includesAbilities: false, thirdPartyAbilities: [] });
+  } catch {
+    return bad("Approved, but saving failed — please try again.", 500);
+  }
+
+  return NextResponse.json({ ok: true, approved: true, reason: verdict.reason });
+}

--- a/agent-ready-plugins-tracker/app/submit/SubmitForm.tsx
+++ b/agent-ready-plugins-tracker/app/submit/SubmitForm.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+const SITE_KEY = process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY;
+
+// Minimal typing for the Turnstile global we load from Cloudflare's script.
+interface Turnstile {
+  render: (el: HTMLElement, opts: Record<string, unknown>) => string;
+  reset: (id?: string) => void;
+}
+declare global {
+  interface Window {
+    turnstile?: Turnstile;
+  }
+}
+
+const input =
+  "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-wp-blue focus:outline-none focus:ring-1 focus:ring-wp-blue";
+const labelCls = "mb-1 block text-sm font-medium text-slate-700";
+
+type Result = { kind: "ok" | "rejected" | "error"; message: string };
+
+export default function SubmitForm() {
+  const [name, setName] = useState("");
+  const [slug, setSlug] = useState("");
+  const [link, setLink] = useState("");
+  const [token, setToken] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [result, setResult] = useState<Result | null>(null);
+
+  const widgetRef = useRef<HTMLDivElement>(null);
+  const widgetId = useRef<string | null>(null);
+
+  // Load + render the Cloudflare Turnstile widget (only when a site key is set).
+  useEffect(() => {
+    if (!SITE_KEY) return;
+    function render() {
+      if (window.turnstile && widgetRef.current && widgetId.current === null) {
+        widgetId.current = window.turnstile.render(widgetRef.current, {
+          sitekey: SITE_KEY,
+          callback: (t: string) => setToken(t),
+          "error-callback": () => setToken(""),
+          "expired-callback": () => setToken(""),
+        });
+      }
+    }
+    if (window.turnstile) {
+      render();
+      return;
+    }
+    const s = document.createElement("script");
+    s.src = "https://challenges.cloudflare.com/turnstile/v0/api.js";
+    s.async = true;
+    s.defer = true;
+    s.onload = render;
+    document.head.appendChild(s);
+  }, []);
+
+  const needsToken = !!SITE_KEY;
+  const canSubmit = name.trim() && slug.trim() && link.trim() && (!needsToken || token) && !busy;
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!canSubmit) return;
+    setBusy(true);
+    setResult(null);
+    try {
+      const res = await fetch("/api/submit", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: name.trim(), slug: slug.trim(), link: link.trim(), turnstileToken: token }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (data?.ok) {
+        setResult({ kind: "ok", message: data.reason || "Approved and added to the directory!" });
+        setName("");
+        setSlug("");
+        setLink("");
+      } else if (data?.approved === false) {
+        setResult({ kind: "rejected", message: data.error || "Not approved." });
+      } else {
+        setResult({ kind: "error", message: data?.error || `Something went wrong (HTTP ${res.status}).` });
+      }
+    } catch (e) {
+      setResult({ kind: "error", message: e instanceof Error ? e.message : "Request failed." });
+    } finally {
+      // Each token is single-use — reset the widget so a retry gets a fresh one.
+      setToken("");
+      if (window.turnstile && widgetId.current) window.turnstile.reset(widgetId.current);
+      setBusy(false);
+    }
+  }
+
+  return (
+    <form onSubmit={submit} className="space-y-5">
+      <div>
+        <label className={labelCls}>Plugin name</label>
+        <input className={input} value={name} onChange={(e) => setName(e.target.value)} placeholder="WooCommerce" maxLength={99} />
+      </div>
+      <div>
+        <label className={labelCls}>Plugin slug</label>
+        <input className={input} value={slug} onChange={(e) => setSlug(e.target.value)} placeholder="woocommerce/woocommerce.php" maxLength={99} />
+        <p className="mt-1 text-xs text-slate-400">The plugin folder/main file, e.g. <code>woocommerce/woocommerce.php</code>.</p>
+      </div>
+      <div>
+        <label className={labelCls}>Plugin link</label>
+        <input className={input} value={link} onChange={(e) => setLink(e.target.value)} placeholder="https://wordpress.org/plugins/woocommerce/" />
+        <p className="mt-1 text-xs text-slate-400">Its wordpress.org page or commercial site.</p>
+      </div>
+
+      {SITE_KEY ? <div ref={widgetRef} className="min-h-[65px]" /> : null}
+
+      <button
+        type="submit"
+        disabled={!canSubmit}
+        className="rounded-lg bg-wp-blue px-5 py-2.5 font-semibold text-white hover:bg-wp-blue-dark disabled:opacity-60"
+      >
+        {busy ? "Reviewing…" : "Submit for review"}
+      </button>
+
+      {result && (
+        <div
+          className={`rounded-lg px-4 py-3 text-sm ${
+            result.kind === "ok"
+              ? "bg-emerald-50 text-emerald-700"
+              : result.kind === "rejected"
+              ? "bg-amber-50 text-amber-800"
+              : "bg-red-50 text-red-700"
+          }`}
+        >
+          {result.kind === "ok" ? "✓ " : ""}
+          {result.message}
+        </div>
+      )}
+    </form>
+  );
+}

--- a/agent-ready-plugins-tracker/app/submit/page.tsx
+++ b/agent-ready-plugins-tracker/app/submit/page.tsx
@@ -1,0 +1,24 @@
+import type { Metadata } from "next";
+import SubmitForm from "./SubmitForm";
+
+export const metadata: Metadata = {
+  title: "Submit a plugin — Agent Ready Plugins Tracker",
+  description: "Submit a WordPress plugin to the directory. Submissions are automatically reviewed.",
+};
+
+export const dynamic = "force-dynamic";
+
+export default function SubmitPage() {
+  return (
+    <main className="mx-auto max-w-xl px-4 py-10">
+      <h1 className="text-3xl font-bold tracking-tight text-slate-900">Submit a plugin</h1>
+      <p className="mt-2 text-slate-600">
+        Suggest a WordPress plugin for the directory. Submissions are automatically reviewed — if it
+        checks out as a real plugin, it&apos;s added right away.
+      </p>
+      <div className="mt-8">
+        <SubmitForm />
+      </div>
+    </main>
+  );
+}

--- a/agent-ready-plugins-tracker/components/Header.tsx
+++ b/agent-ready-plugins-tracker/components/Header.tsx
@@ -5,6 +5,7 @@ const NAV = [
   { href: "/updates", label: "Updates" },
   { href: "/about", label: "About" },
   { href: "/contribute", label: "Contribute" },
+  { href: "/submit", label: "Submit" },
   { href: "/disclaimer", label: "Disclaimer" },
 ];
 

--- a/agent-ready-plugins-tracker/lib/db.ts
+++ b/agent-ready-plugins-tracker/lib/db.ts
@@ -34,6 +34,14 @@ export async function getPluginByUrlSlug(urlSlug: string): Promise<Plugin | null
   return data ? rowToPlugin(data) : null;
 }
 
+/** Whether a plugin with this exact slug (plugin file) already exists. */
+export async function pluginExists(slug: string): Promise<boolean> {
+  const supabase = getClient();
+  if (!supabase) return false;
+  const { data } = await supabase.from("plugins").select("slug").eq("slug", slug).maybeSingle();
+  return !!data;
+}
+
 /** Look up a plugin by its primary key (the full plugin file). */
 export async function getPlugin(slug: string): Promise<Plugin | null> {
   const supabase = getClient();

--- a/agent-ready-plugins-tracker/lib/moderation.ts
+++ b/agent-ready-plugins-tracker/lib/moderation.ts
@@ -1,0 +1,53 @@
+import { generateObject } from "ai";
+import { z } from "zod";
+
+const MODEL = process.env.AI_RESEARCH_MODEL || "perplexity/sonar";
+
+const schema = z.object({
+  approved: z
+    .boolean()
+    .describe("true only if this is a real, identifiable WordPress plugin that belongs in the directory"),
+  reason: z.string().describe("one short sentence explaining the decision"),
+});
+
+export interface ModerationResult {
+  approved: boolean;
+  reason: string;
+}
+
+/**
+ * AI moderator for a public plugin submission. Uses a web-search-capable model to
+ * confirm the plugin is real before it gets listed. Fails closed (not approved)
+ * if the gateway isn't configured or the call errors.
+ */
+export async function moderateSubmission(input: {
+  name: string;
+  slug: string;
+  link: string;
+}): Promise<ModerationResult> {
+  if (!process.env.AI_GATEWAY_API_KEY) {
+    return { approved: false, reason: "Moderation is unavailable right now — please try again later." };
+  }
+
+  const prompt = `You are the moderator for a public directory of real WordPress plugins. A user submitted a plugin to be listed. Decide whether to approve it.
+
+Submission:
+- Name: "${input.name}"
+- Slug: "${input.slug}"
+- Link: ${input.link}
+
+Approve ONLY if ALL of these hold, verified against current web sources:
+- The name is correct for a real WordPress plugin.
+- The slug is believable (it looks like a real wordpress.org slug, or the plugin folder/main file, for this plugin).
+- The link goes to a valid website that actually describes this plugin (its wordpress.org page, its commercial site, or its source repo).
+- This is a real WordPress plugin that exists and that people have heard of — not spam, not invented, not a placeholder.
+
+Reject anything spammy, fake, unverifiable, or that you cannot confirm is a real WordPress plugin. Return approved (boolean) and a one-sentence reason.`;
+
+  try {
+    const { object } = await generateObject({ model: MODEL, schema, prompt, temperature: 0 });
+    return { approved: object.approved, reason: object.reason };
+  } catch {
+    return { approved: false, reason: "Couldn't verify the submission automatically — please try again later." };
+  }
+}

--- a/agent-ready-plugins-tracker/lib/turnstile.ts
+++ b/agent-ready-plugins-tracker/lib/turnstile.ts
@@ -1,0 +1,28 @@
+const VERIFY_URL = "https://challenges.cloudflare.com/turnstile/v0/siteverify";
+
+/** Whether Turnstile is configured (a secret is set). */
+export function turnstileConfigured(): boolean {
+  return !!process.env.TURNSTILE_SECRET_KEY;
+}
+
+/**
+ * Verify a Cloudflare Turnstile token server-side. When no secret is configured
+ * (e.g. local dev), verification is skipped and returns true so the form still
+ * works — set TURNSTILE_SECRET_KEY in production to actually enforce it.
+ */
+export async function verifyTurnstile(token: string | undefined, ip?: string): Promise<boolean> {
+  const secret = process.env.TURNSTILE_SECRET_KEY;
+  if (!secret) return true; // not configured — skip (dev convenience)
+  if (!token) return false;
+  try {
+    const form = new URLSearchParams();
+    form.set("secret", secret);
+    form.set("response", token);
+    if (ip) form.set("remoteip", ip);
+    const res = await fetch(VERIFY_URL, { method: "POST", body: form });
+    const data = (await res.json()) as { success?: boolean };
+    return !!data.success;
+  } catch {
+    return false;
+  }
+}

--- a/agent-ready-plugins-tracker/lib/url-check.ts
+++ b/agent-ready-plugins-tracker/lib/url-check.ts
@@ -1,0 +1,65 @@
+export interface UrlCheck {
+  ok: boolean;
+  status?: number;
+  error?: string;
+}
+
+/** Block obvious internal/loopback/private hosts to limit SSRF from user-supplied URLs. */
+function isPrivateHost(host: string): boolean {
+  const h = host.toLowerCase().replace(/^\[|\]$/g, "");
+  if (h === "localhost" || h.endsWith(".local") || h.endsWith(".localhost")) return true;
+  if (h === "::1" || h.startsWith("fc") || h.startsWith("fd") || h.startsWith("fe80")) return true; // IPv6 loopback / ULA / link-local
+  const m = h.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+  if (m) {
+    const a = Number(m[1]);
+    const b = Number(m[2]);
+    if (a === 0 || a === 127 || a === 10) return true;
+    if (a === 169 && b === 254) return true;
+    if (a === 192 && b === 168) return true;
+    if (a === 172 && b >= 16 && b <= 31) return true;
+  }
+  return false;
+}
+
+/**
+ * Validate that a user-supplied plugin URL is an http(s) link to a reachable
+ * site (not a 404 / error / unreachable host). Best-effort, with a timeout and a
+ * basic SSRF guard.
+ */
+export async function checkPluginUrl(rawUrl: string): Promise<UrlCheck> {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    return { ok: false, error: "That doesn't look like a valid URL." };
+  }
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    return { ok: false, error: "URL must start with http:// or https://." };
+  }
+  if (isPrivateHost(url.hostname)) {
+    return { ok: false, error: "That URL host isn't allowed." };
+  }
+
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), 8000);
+  try {
+    const res = await fetch(url.toString(), {
+      method: "GET",
+      redirect: "follow",
+      signal: ctrl.signal,
+      headers: {
+        "User-Agent": "AgentReadyPluginsTracker/1.0 (+submission check)",
+        Accept: "text/html,application/xhtml+xml,*/*",
+      },
+    });
+    if (res.status >= 400) {
+      return { ok: false, status: res.status, error: `The link returned HTTP ${res.status}.` };
+    }
+    return { ok: true, status: res.status };
+  } catch (e) {
+    const aborted = e instanceof Error && e.name === "AbortError";
+    return { ok: false, error: aborted ? "The link timed out." : "The link couldn't be reached." };
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/agent-ready-plugins-tracker/middleware.ts
+++ b/agent-ready-plugins-tracker/middleware.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 
 // /admin self-gates on the ADMIN_SECRET (see lib/admin-auth), independent of the
 // public site password; /api/admin routes carry their own checks.
-const PUBLIC_PATHS = ["/login", "/api/auth", "/api/ability-packs", "/admin", "/api/admin"];
+const PUBLIC_PATHS = ["/login", "/api/auth", "/api/ability-packs", "/admin", "/api/admin", "/submit", "/api/submit"];
 
 export function middleware(req: NextRequest) {
   const { pathname } = req.nextUrl;


### PR DESCRIPTION
Adds a public `/submit` page where anyone can suggest a plugin, auto-moderated by AI.

### Flow (cheapest checks first)
1. **Cloudflare Turnstile** bot check — verified server-side. Skipped if `TURNSTILE_SECRET_KEY` is unset (dev convenience).
2. **Length sanity** — name and slug each under 100 chars.
3. **Duplicate check** — rejects plugins already in the directory (by slug or url-slug).
4. **URL validity** — the link must be http(s) and resolve to a reachable, non-404 site; basic SSRF guard blocks private/loopback hosts.
5. **AI moderation** — a web-search-backed model confirms it's a real, known WordPress plugin (correct name, believable slug, link that describes it) before listing.

Approved → added immediately (`includes_abilities=false`, no third-party yet); the daily AI check fills in abilities later. Rejected → the reason is shown to the user.

### Wiring
- `/submit` + `/api/submit` added to the middleware public paths (so they bypass the site password gate).
- New **Submit** nav link.
- New env vars `NEXT_PUBLIC_TURNSTILE_SITE_KEY` / `TURNSTILE_SECRET_KEY` (documented in `.env.example`).

Tracker-only — no plugin release. `tsc` + `npm run build` pass; `/submit` verified rendering and publicly reachable while `/` stays gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)