### PR TITLE
feat(tracker): resolve canonical plugin slug + name via the moderator

### DIFF
--- a/agent-ready-plugins-tracker/app/api/submit/route.ts
+++ b/agent-ready-plugins-tracker/app/api/submit/route.ts
@@ -50,18 +50,28 @@ export async function POST(req: NextRequest) {
     return bad(urlCheck.error ?? "The plugin link doesn't resolve to a working site.");
   }
 
-  // 5. AI moderation — is this a real, listable WordPress plugin?
+  // 5. AI moderation — is this a real, listable WordPress plugin? The model also
+  //    returns the canonical name + "folder/main.php" slug read from public code.
   const verdict = await moderateSubmission({ name, slug, link });
   if (!verdict.approved) {
     return NextResponse.json({ ok: false, approved: false, error: `Not approved: ${verdict.reason}` });
   }
 
+  // Prefer the AI's canonical identity over the user's input.
+  const finalSlug = verdict.canonicalSlug && verdict.canonicalSlug.length < MAX_LEN ? verdict.canonicalSlug : slug;
+  const finalName = verdict.canonicalName && verdict.canonicalName.length < MAX_LEN ? verdict.canonicalName : name;
+
+  // If the canonical slug differs from what was submitted, re-check for a duplicate.
+  if (finalSlug !== slug && ((await pluginExists(finalSlug)) || (await getPluginByUrlSlug(folderSlug(finalSlug))))) {
+    return bad("That plugin is already in the directory.", 409);
+  }
+
   // Approved — add it. The daily AI check fills in abilities later.
   try {
-    await upsertPlugin({ slug, name, link, includesAbilities: false, thirdPartyAbilities: [] });
+    await upsertPlugin({ slug: finalSlug, name: finalName, link, includesAbilities: false, thirdPartyAbilities: [] });
   } catch {
     return bad("Approved, but saving failed — please try again.", 500);
   }
 
-  return NextResponse.json({ ok: true, approved: true, reason: verdict.reason });
+  return NextResponse.json({ ok: true, approved: true, reason: verdict.reason, name: finalName, slug: finalSlug });
 }

--- a/agent-ready-plugins-tracker/app/submit/SubmitForm.tsx
+++ b/agent-ready-plugins-tracker/app/submit/SubmitForm.tsx
@@ -73,7 +73,8 @@ export default function SubmitForm() {
       });
       const data = await res.json().catch(() => ({}));
       if (data?.ok) {
-        setResult({ kind: "ok", message: data.reason || "Approved and added to the directory!" });
+        const added = data.name ? `Added “${data.name}” (${data.slug}).` : "Approved and added to the directory!";
+        setResult({ kind: "ok", message: data.reason ? `${added} ${data.reason}` : added });
         setName("");
         setSlug("");
         setLink("");

--- a/agent-ready-plugins-tracker/lib/moderation.ts
+++ b/agent-ready-plugins-tracker/lib/moderation.ts
@@ -8,17 +8,29 @@ const schema = z.object({
     .boolean()
     .describe("true only if this is a real, identifiable WordPress plugin that belongs in the directory"),
   reason: z.string().describe("one short sentence explaining the decision"),
+  canonicalName: z.string().describe('the plugin\'s correct official name (empty string if unknown)'),
+  canonicalSlug: z
+    .string()
+    .describe(
+      'the plugin\'s canonical slug as "folder/main-plugin-file.php" (e.g. "wordpress-seo/wp-seo.php"). ' +
+        "The folder is the wordpress.org slug; the main file is the PHP file in the plugin folder's root that " +
+        'carries the "Plugin Name:" header. Determine the exact file name from the plugin\'s public code — e.g. ' +
+        "browse https://plugins.trac.wordpress.org/browser/<slug>/trunk — do NOT guess the file name. Empty string if it can't be determined."
+    ),
 });
 
 export interface ModerationResult {
   approved: boolean;
   reason: string;
+  canonicalName?: string;
+  canonicalSlug?: string;
 }
 
 /**
- * AI moderator for a public plugin submission. Uses a web-search-capable model to
- * confirm the plugin is real before it gets listed. Fails closed (not approved)
- * if the gateway isn't configured or the call errors.
+ * AI moderator for a public plugin submission. A web-capable model confirms the
+ * plugin is real and, when it is, returns its canonical name + "folder/main.php"
+ * slug (read from the plugin's public code, not guessed). Fails closed if the
+ * gateway isn't configured or the call errors.
  */
 export async function moderateSubmission(input: {
   name: string;
@@ -29,24 +41,29 @@ export async function moderateSubmission(input: {
     return { approved: false, reason: "Moderation is unavailable right now — please try again later." };
   }
 
-  const prompt = `You are the moderator for a public directory of real WordPress plugins. A user submitted a plugin to be listed. Decide whether to approve it.
+  const prompt = `You are the moderator for a public directory of real WordPress plugins. A user submitted a plugin to be listed.
 
 Submission:
 - Name: "${input.name}"
 - Slug: "${input.slug}"
 - Link: ${input.link}
 
-Approve ONLY if ALL of these hold, verified against current web sources:
-- The name is correct for a real WordPress plugin.
-- The slug is believable (it looks like a real wordpress.org slug, or the plugin folder/main file, for this plugin).
-- The link goes to a valid website that actually describes this plugin (its wordpress.org page, its commercial site, or its source repo).
-- This is a real WordPress plugin that exists and that people have heard of — not spam, not invented, not a placeholder.
+Step 1 — decide whether to APPROVE it. Approve ONLY if, verified against current web sources, this is a real WordPress plugin that exists and is known (not spam, fake, or unverifiable): the name is correct, the slug is believable, and the link goes to a site that actually describes this plugin.
 
-Reject anything spammy, fake, unverifiable, or that you cannot confirm is a real WordPress plugin. Return approved (boolean) and a one-sentence reason.`;
+Step 2 — if (and only if) it's a real plugin, determine its CANONICAL identity from public sources:
+- canonicalName: the plugin's official name.
+- canonicalSlug: "folder/main-plugin-file.php". The folder is the wordpress.org slug. The main file is the PHP file in the plugin's trunk root that has the "Plugin Name:" header — look at the plugin's public code (e.g. https://plugins.trac.wordpress.org/browser/<slug>/trunk, or its wordpress.org page) to find the EXACT file name. Do not guess it. For a commercial plugin not on wordpress.org, give your best-known folder/main file.
+
+Return approved, a one-sentence reason, canonicalName, and canonicalSlug.`;
 
   try {
     const { object } = await generateObject({ model: MODEL, schema, prompt, temperature: 0 });
-    return { approved: object.approved, reason: object.reason };
+    return {
+      approved: object.approved,
+      reason: object.reason,
+      canonicalName: object.canonicalName?.trim() || undefined,
+      canonicalSlug: object.canonicalSlug?.trim() || undefined,
+    };
   } catch {
     return { approved: false, reason: "Couldn't verify the submission automatically — please try again later." };
   }


### PR DESCRIPTION
The AI moderator now does double duty: besides approving/rejecting, it returns the plugin's **canonical name** and **`folder/main-plugin-file.php`** slug, read from the plugin's public code (e.g. its trunk on plugins.trac.wordpress.org) rather than guessed. This fixes cases where the main file differs from the folder (e.g. `wordpress-seo/wp-seo.php`).

- Approved submissions are listed under the canonical name/slug, not the user's raw input.
- Duplicate re-check runs against the resolved slug before insert.
- Success message shows the resolved name + slug.

No SVN/HTTP scraping in our code — the model determines it. Tracker-only, no plugin release. `tsc` + `npm run build` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)