### PR TITLE
feat(tracker): GPT-5 + web search for AI research & moderation; strict prompt

### DIFF
--- a/agent-ready-plugins-tracker/.env.example
+++ b/agent-ready-plugins-tracker/.env.example
@@ -27,13 +27,13 @@ TURNSTILE_SECRET_KEY=
 #   https://github.com/soflyy/agent-connector-for-wp/releases/download/pack-index/index.json
 PACK_INDEX_URL=
 
-# AI status check (Vercel AI Gateway). Researches each plugin's AI-ability status
-# via live web search and writes typed results to the DB.
-# AI_GATEWAY_API_KEY — required to run the check (Vercel → AI Gateway).
+# AI research + submission moderation. Uses OpenAI GPT-5 with the built-in
+# web_search tool (the OpenAI Responses API), so it reasons over live web sources.
+# OPENAI_API_KEY — required for the AI re-check and submission moderation.
+# AI_RESEARCH_MODEL — optional, defaults to gpt-5 (any web-search-capable OpenAI model).
 # CRON_SECRET — required so the daily cron can authenticate (Vercel sends it as a Bearer token).
-# AI_RESEARCH_MODEL — optional, defaults to perplexity/sonar (live web search + citations).
 # AI_CHECK_BATCH — optional, plugins re-checked per cron run (default 25, stalest first).
-AI_GATEWAY_API_KEY=
-CRON_SECRET=
+OPENAI_API_KEY=
 AI_RESEARCH_MODEL=
+CRON_SECRET=
 AI_CHECK_BATCH=

--- a/agent-ready-plugins-tracker/app/admin/AdminClient.tsx
+++ b/agent-ready-plugins-tracker/app/admin/AdminClient.tsx
@@ -10,11 +10,11 @@ const input =
 
 interface AiDebug {
   model?: string;
-  temperature?: number;
   prompt?: string;
   request?: unknown;
   rawResponse?: unknown;
   object?: unknown;
+  sources?: unknown;
   usage?: unknown;
   finishReason?: string;
   warnings?: unknown;
@@ -85,8 +85,6 @@ function DebugModal({ slug, data, onClose }: { slug: string; data: CheckData; on
 
         <p className="mt-4 text-sm text-slate-600">
           <span className="font-medium">Model:</span> <code>{d.model ?? "—"}</code>
-          {" · "}
-          <span className="font-medium">temperature:</span> {String(d.temperature ?? "—")}
           {d.finishReason ? <> {" · "} <span className="font-medium">finish:</span> {d.finishReason}</> : null}
         </p>
 
@@ -94,6 +92,7 @@ function DebugModal({ slug, data, onClose }: { slug: string; data: CheckData; on
         <DebugSection title="Request sent to provider" value={d.request} />
         <DebugSection title="Raw response from provider" value={d.rawResponse} />
         <DebugSection title="Parsed object" value={d.object} />
+        <DebugSection title="Sources (web search)" value={d.sources} />
         <DebugSection title="Usage" value={d.usage} />
         {d.warnings ? <DebugSection title="Warnings" value={d.warnings} /> : null}
       </div>

--- a/agent-ready-plugins-tracker/lib/ai-research.ts
+++ b/agent-ready-plugins-tracker/lib/ai-research.ts
@@ -1,102 +1,68 @@
-import { generateObject } from "ai";
 import { z } from "zod";
 import type { AIResearchResult } from "./types";
-
-// Model routed through the Vercel AI Gateway (uses AI_GATEWAY_API_KEY). Perplexity
-// Sonar performs live web search with citations, so a single call both researches
-// and returns structured output. Override with AI_RESEARCH_MODEL.
-const MODEL = process.env.AI_RESEARCH_MODEL || "perplexity/sonar";
-const TEMPERATURE = 0;
+import { webSearchObject, type WebSearchDebug } from "./ai";
 
 const schema = z.object({
   pluginIncludesOfficialAbilities: z
     .boolean()
     .describe(
-      "true if the plugin itself ships first-party AI abilities (e.g. via the WordPress Abilities API / MCP Adapter or its own MCP server). " +
-        "false if there is no shipped first-party support (including when official support is only announced, not yet released)."
+      "true ONLY if the plugin itself (first-party) registers capabilities through the WordPress Abilities API that are exposed to AI agents over MCP. " +
+        "Generic AI features (chatbots, content/copy generation, recommendations) do NOT count. " +
+        "false if that MCP-accessible WP-Abilities support is not actually shipped (announced-but-unreleased = false)."
     ),
   thirdPartyAbilitiesProvidedBy: z
     .array(
       z.object({
-        pluginName: z.string().describe("Name of the third-party plugin that adds AI abilities for this plugin."),
+        pluginName: z.string().describe("Name of the third-party plugin that registers WP Abilities (over MCP) to control the source plugin."),
         pluginSlug: z.string().describe("Its wordpress.org slug or plugin folder, if known (else empty)."),
         pluginLink: z.string().describe("URL to that third-party plugin."),
       })
     )
-    .describe("Third-party / unofficial plugins that provide AI abilities or an MCP server for this plugin (empty if none)."),
+    .describe(
+      "Third-party plugins that register WordPress Abilities (via the WP Abilities API) exposed over MCP specifically to control the SOURCE plugin. " +
+        "Exclude any plugin that only adds generic AI functionality and does not expose MCP abilities for the source plugin. Empty array if none qualify."
+    ),
 });
 
-/**
- * Everything sent to and returned from the LLM for one research call — surfaced
- * in the admin UI so a re-check is fully inspectable. `request`/`rawResponse`
- * come straight from the AI SDK (the actual provider HTTP bodies).
- */
-export interface ResearchDebug {
-  model: string;
-  temperature: number;
-  prompt: string;
-  request?: unknown;
-  rawResponse?: unknown;
-  object?: AIResearchResult;
-  usage?: unknown;
-  finishReason?: string;
-  warnings?: unknown;
-}
+// Re-exported so callers (ai-check) keep a stable type name.
+export type ResearchDebug = WebSearchDebug;
 
 export type ResearchOutcome =
   | { ok: true; result: AIResearchResult; debug: ResearchDebug }
   | { ok: false; error: string; debug: ResearchDebug };
 
 function buildPrompt(slug: string, name: string): string {
-  return `You are researching the WordPress plugin "${name}" (slug "${slug}") as of today.
+  return `You are assessing the WordPress plugin "${name}" (slug "${slug}") as of today, using current web sources.
 
-Determine, using current web sources, exactly two things:
-1. Does the plugin ship its OWN first-party AI abilities (e.g. via the WordPress Abilities API introduced in WP 6.9, the WordPress MCP Adapter, or its own MCP server)? Be conservative — only say true with a credible first-party source. Announced-but-not-shipped support counts as false.
-2. Are there THIRD-PARTY / unofficial plugins or MCP servers that add AI abilities for this plugin? List each with its name, slug, and URL.`;
+The ONLY thing that matters is the WordPress Abilities API + MCP. Definitions — be strict:
+- An "ability" = a capability registered through the WordPress Abilities API (e.g. wp_register_ability(), introduced in WP 6.9) that is exposed to AI agents over MCP (the Model Context Protocol) — via the WordPress MCP Adapter or an MCP server — so an agent can programmatically read/control the plugin.
+- Generic "AI features" DO NOT COUNT: AI chatbots, AI copy/content generation, product recommendations, AI search, etc., are NOT abilities unless they register MCP-accessible abilities via the WP Abilities API to control the plugin.
+
+Determine exactly two things:
+1. pluginIncludesOfficialAbilities — Does "${name}" ITSELF (first-party) register WordPress Abilities exposed over MCP to control it? Only true with a credible first-party source showing this is actually shipped (not merely announced).
+2. thirdPartyAbilitiesProvidedBy — Which THIRD-PARTY plugins register WordPress Abilities (over MCP), via the WP Abilities API, specifically to control "${name}"? Include a plugin ONLY if it adds MCP-accessible abilities to control "${name}". Exclude anything that only adds generic AI functionality. If none qualify, return an empty array — empty is the expected answer for most plugins.`;
 }
 
 /**
- * Research a WordPress plugin via live web search and determine two things:
- * whether it now ships official abilities, and which third-party plugins provide
- * abilities for it. Never throws — returns a typed outcome carrying the full
- * debug payload (prompt, params, raw request + response) for the admin UI.
+ * Research a plugin's WP-Abilities/MCP status with GPT-5 + web search. Never
+ * throws — returns a typed outcome carrying the full debug payload for the admin UI.
  */
 export async function researchPlugin(slug: string, name: string): Promise<ResearchOutcome> {
-  const prompt = buildPrompt(slug, name);
-  const debug: ResearchDebug = { model: MODEL, temperature: TEMPERATURE, prompt };
-
-  if (!process.env.AI_GATEWAY_API_KEY) {
-    return { ok: false, error: "AI_GATEWAY_API_KEY is not set", debug };
+  const res = await webSearchObject({ prompt: buildPrompt(slug, name), schema });
+  if (!res.ok) {
+    return { ok: false, error: res.error, debug: res.debug };
   }
-
-  try {
-    const gen = await generateObject({ model: MODEL, schema, prompt, temperature: TEMPERATURE });
-    debug.request = gen.request?.body;
-    debug.rawResponse = gen.response?.body;
-    debug.object = gen.object;
-    debug.usage = gen.usage;
-    debug.finishReason = gen.finishReason;
-    debug.warnings = gen.warnings;
-
-    const result: AIResearchResult = {
-      pluginIncludesOfficialAbilities: gen.object.pluginIncludesOfficialAbilities,
-      thirdPartyAbilitiesProvidedBy: (gen.object.thirdPartyAbilitiesProvidedBy ?? []).map((u) => ({
+  const o = res.object;
+  return {
+    ok: true,
+    result: {
+      pluginIncludesOfficialAbilities: o.pluginIncludesOfficialAbilities,
+      thirdPartyAbilitiesProvidedBy: (o.thirdPartyAbilitiesProvidedBy ?? []).map((u) => ({
         pluginName: u.pluginName,
         pluginSlug: u.pluginSlug,
         pluginLink: u.pluginLink,
       })),
-    };
-    return { ok: true, result, debug };
-  } catch (e) {
-    // The AI SDK attaches the raw request/response (and the model's text, when it
-    // returned something unparseable) to the thrown error — surface it.
-    const err = e as { request?: { body?: unknown }; response?: { body?: unknown }; text?: unknown; cause?: { message?: string } };
-    debug.request = err?.request?.body ?? debug.request;
-    debug.rawResponse = err?.response?.body ?? err?.text ?? null;
-    return {
-      ok: false,
-      error: e instanceof Error ? e.message : String(e),
-      debug,
-    };
-  }
+    },
+    debug: res.debug,
+  };
 }

--- a/agent-ready-plugins-tracker/lib/ai.ts
+++ b/agent-ready-plugins-tracker/lib/ai.ts
@@ -1,0 +1,70 @@
+import { openai } from "@ai-sdk/openai";
+import { generateText, Output } from "ai";
+import type { z } from "zod";
+
+// GPT-5 (via the OpenAI Responses API) with the built-in web_search tool — gives
+// up-to-date, reasoned answers for the niche WP Abilities / MCP questions we ask.
+// Override the model with AI_RESEARCH_MODEL. Requires OPENAI_API_KEY.
+export const RESEARCH_MODEL = process.env.AI_RESEARCH_MODEL || "gpt-5";
+
+/** Everything sent to / returned from the model for one call — surfaced in admin. */
+export interface WebSearchDebug {
+  model: string;
+  prompt: string;
+  request?: unknown;
+  rawResponse?: unknown;
+  object?: unknown;
+  sources?: unknown;
+  usage?: unknown;
+  finishReason?: string;
+  warnings?: unknown;
+}
+
+export type WebSearchResult<T> =
+  | { ok: true; object: T; debug: WebSearchDebug }
+  | { ok: false; error: string; debug: WebSearchDebug };
+
+/**
+ * Run one web-search-grounded, structured-output call: the model may use OpenAI's
+ * server-side web_search tool, then returns an object matching `schema`. Never
+ * throws — returns a typed result carrying the full debug payload.
+ */
+export async function webSearchObject<T>(opts: {
+  prompt: string;
+  schema: z.ZodType<T>;
+  model?: string;
+}): Promise<WebSearchResult<T>> {
+  const model = opts.model || RESEARCH_MODEL;
+  const debug: WebSearchDebug = { model, prompt: opts.prompt };
+
+  if (!process.env.OPENAI_API_KEY) {
+    return { ok: false, error: "OPENAI_API_KEY is not set", debug };
+  }
+
+  try {
+    const result = await generateText({
+      model: openai.responses(model),
+      tools: { web_search: openai.tools.webSearch({}) },
+      prompt: opts.prompt,
+      experimental_output: Output.object({ schema: opts.schema }),
+    });
+    debug.request = result.request?.body;
+    debug.rawResponse = result.response?.body;
+    debug.sources = result.sources;
+    debug.usage = result.usage;
+    debug.finishReason = result.finishReason;
+    debug.warnings = result.warnings;
+
+    const object = result.experimental_output as T | undefined;
+    debug.object = object;
+    if (object === undefined || object === null) {
+      return { ok: false, error: "The model returned no structured output.", debug };
+    }
+    return { ok: true, object, debug };
+  } catch (e) {
+    const err = e as { request?: { body?: unknown }; response?: { body?: unknown }; text?: unknown };
+    debug.request = err?.request?.body ?? debug.request;
+    debug.rawResponse = err?.response?.body ?? err?.text ?? null;
+    return { ok: false, error: e instanceof Error ? e.message : String(e), debug };
+  }
+}

--- a/agent-ready-plugins-tracker/lib/moderation.ts
+++ b/agent-ready-plugins-tracker/lib/moderation.ts
@@ -1,14 +1,12 @@
-import { generateObject } from "ai";
 import { z } from "zod";
-
-const MODEL = process.env.AI_RESEARCH_MODEL || "perplexity/sonar";
+import { webSearchObject } from "./ai";
 
 const schema = z.object({
   approved: z
     .boolean()
     .describe("true only if this is a real, identifiable WordPress plugin that belongs in the directory"),
   reason: z.string().describe("one short sentence explaining the decision"),
-  canonicalName: z.string().describe('the plugin\'s correct official name (empty string if unknown)'),
+  canonicalName: z.string().describe("the plugin's correct official name (empty string if unknown)"),
   canonicalSlug: z
     .string()
     .describe(
@@ -27,20 +25,16 @@ export interface ModerationResult {
 }
 
 /**
- * AI moderator for a public plugin submission. A web-capable model confirms the
- * plugin is real and, when it is, returns its canonical name + "folder/main.php"
- * slug (read from the plugin's public code, not guessed). Fails closed if the
- * gateway isn't configured or the call errors.
+ * AI moderator for a public plugin submission, using GPT-5 + web search. Confirms
+ * the plugin is real and, when it is, returns its canonical name + "folder/main.php"
+ * slug (read from the plugin's public code). Fails closed (not approved) if the
+ * model is unavailable or errors.
  */
 export async function moderateSubmission(input: {
   name: string;
   slug: string;
   link: string;
 }): Promise<ModerationResult> {
-  if (!process.env.AI_GATEWAY_API_KEY) {
-    return { approved: false, reason: "Moderation is unavailable right now — please try again later." };
-  }
-
   const prompt = `You are the moderator for a public directory of real WordPress plugins. A user submitted a plugin to be listed.
 
 Submission:
@@ -56,15 +50,14 @@ Step 2 — if (and only if) it's a real plugin, determine its CANONICAL identity
 
 Return approved, a one-sentence reason, canonicalName, and canonicalSlug.`;
 
-  try {
-    const { object } = await generateObject({ model: MODEL, schema, prompt, temperature: 0 });
-    return {
-      approved: object.approved,
-      reason: object.reason,
-      canonicalName: object.canonicalName?.trim() || undefined,
-      canonicalSlug: object.canonicalSlug?.trim() || undefined,
-    };
-  } catch {
+  const res = await webSearchObject({ prompt, schema });
+  if (!res.ok) {
     return { approved: false, reason: "Couldn't verify the submission automatically — please try again later." };
   }
+  return {
+    approved: res.object.approved,
+    reason: res.object.reason,
+    canonicalName: res.object.canonicalName?.trim() || undefined,
+    canonicalSlug: res.object.canonicalSlug?.trim() || undefined,
+  };
 }

--- a/agent-ready-plugins-tracker/package-lock.json
+++ b/agent-ready-plugins-tracker/package-lock.json
@@ -8,6 +8,7 @@
       "name": "agent-ready-plugins-tracker",
       "version": "0.1.0",
       "dependencies": {
+        "@ai-sdk/openai": "^3.0.68",
         "@supabase/supabase-js": "^2.107.0",
         "ai": "^6.0.197",
         "autoprefixer": "^10.5.0",
@@ -37,6 +38,22 @@
         "@ai-sdk/provider": "3.0.10",
         "@ai-sdk/provider-utils": "4.0.27",
         "@vercel/oidc": "3.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/openai": {
+      "version": "3.0.68",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-3.0.68.tgz",
+      "integrity": "sha512-FCs/DPr4M95UyZ/ABHJmTmCEYRCka/4J0Bna0nsd78QCdGIS0X/zhn+fVzB7mZJo7464uOWYUjROx9PGNGOb0w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.10",
+        "@ai-sdk/provider-utils": "4.0.27"
       },
       "engines": {
         "node": ">=18"

--- a/agent-ready-plugins-tracker/package.json
+++ b/agent-ready-plugins-tracker/package.json
@@ -10,6 +10,7 @@
     "seed": "tsx scripts/seed.ts"
   },
   "dependencies": {
+    "@ai-sdk/openai": "^3.0.68",
     "@supabase/supabase-js": "^2.107.0",
     "ai": "^6.0.197",
     "autoprefixer": "^10.5.0",


### PR DESCRIPTION
### Why
The AI re-check was matching generic "AI plugins for X" (chatbots, copy gen, recommendations) because (a) the prompt was loose and (b) base `perplexity/sonar` is a weak reasoner. We only care about capabilities registered via the **WP Abilities API and exposed over MCP**.

### Changes
- **Model:** switched the AI re-check **and** submission moderation to **OpenAI GPT-5 + the built-in `web_search` tool** (OpenAI Responses API), via a shared `lib/ai.ts` helper (`generateText` + `web_search` + structured `Output`). Replaces the Perplexity-via-AI-Gateway path.
- **Strict prompt:** an "ability" = registered through the WordPress Abilities API and reachable over MCP to control the plugin. Generic AI features explicitly don't count; an empty third-party list is the expected answer for most plugins.
- **Debug modal:** now surfaces the web-search **sources**; drops the temperature line (GPT-5 ignores it).
- **Env:** AI features now require **`OPENAI_API_KEY`** (+ optional `AI_RESEARCH_MODEL`, default `gpt-5`). `AI_GATEWAY_API_KEY` is no longer used.

Tracker-only — no plugin release. `tsc` + `npm run build` pass. Not runtime-verified (needs `OPENAI_API_KEY`); the debug modal will show the exact request/response/sources once the key is set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)