### PR TITLE
feat(tracker): route GPT-5 + web search through the Vercel AI Gateway

### DIFF
--- a/agent-ready-plugins-tracker/.env.example
+++ b/agent-ready-plugins-tracker/.env.example
@@ -27,13 +27,14 @@ TURNSTILE_SECRET_KEY=
 #   https://github.com/soflyy/agent-connector-for-wp/releases/download/pack-index/index.json
 PACK_INDEX_URL=
 
-# AI research + submission moderation. Uses OpenAI GPT-5 with the built-in
-# web_search tool (the OpenAI Responses API), so it reasons over live web sources.
-# OPENAI_API_KEY — required for the AI re-check and submission moderation.
-# AI_RESEARCH_MODEL — optional, defaults to gpt-5 (any web-search-capable OpenAI model).
+# AI research + submission moderation. Uses GPT-5 with OpenAI's built-in
+# web_search tool, routed through the Vercel AI Gateway, so it reasons over live
+# web sources.
+# AI_GATEWAY_API_KEY — required for the AI re-check and submission moderation.
+# AI_RESEARCH_MODEL — optional, defaults to openai/gpt-5 (any web-search-capable model).
 # CRON_SECRET — required so the daily cron can authenticate (Vercel sends it as a Bearer token).
 # AI_CHECK_BATCH — optional, plugins re-checked per cron run (default 25, stalest first).
-OPENAI_API_KEY=
+AI_GATEWAY_API_KEY=
 AI_RESEARCH_MODEL=
 CRON_SECRET=
 AI_CHECK_BATCH=

--- a/agent-ready-plugins-tracker/lib/ai.ts
+++ b/agent-ready-plugins-tracker/lib/ai.ts
@@ -2,10 +2,10 @@ import { openai } from "@ai-sdk/openai";
 import { generateText, Output } from "ai";
 import type { z } from "zod";
 
-// GPT-5 (via the OpenAI Responses API) with the built-in web_search tool — gives
-// up-to-date, reasoned answers for the niche WP Abilities / MCP questions we ask.
-// Override the model with AI_RESEARCH_MODEL. Requires OPENAI_API_KEY.
-export const RESEARCH_MODEL = process.env.AI_RESEARCH_MODEL || "gpt-5";
+// GPT-5 with OpenAI's built-in web_search tool, routed through the Vercel AI
+// Gateway (a bare model-id string resolves via the gateway; auth is
+// AI_GATEWAY_API_KEY). Override the model with AI_RESEARCH_MODEL.
+export const RESEARCH_MODEL = process.env.AI_RESEARCH_MODEL || "openai/gpt-5";
 
 /** Everything sent to / returned from the model for one call — surfaced in admin. */
 export interface WebSearchDebug {
@@ -37,13 +37,13 @@ export async function webSearchObject<T>(opts: {
   const model = opts.model || RESEARCH_MODEL;
   const debug: WebSearchDebug = { model, prompt: opts.prompt };
 
-  if (!process.env.OPENAI_API_KEY) {
-    return { ok: false, error: "OPENAI_API_KEY is not set", debug };
+  if (!process.env.AI_GATEWAY_API_KEY) {
+    return { ok: false, error: "AI_GATEWAY_API_KEY is not set", debug };
   }
 
   try {
     const result = await generateText({
-      model: openai.responses(model),
+      model, // bare id ("openai/gpt-5") → resolved via the Vercel AI Gateway
       tools: { web_search: openai.tools.webSearch({}) },
       prompt: opts.prompt,
       experimental_output: Output.object({ schema: opts.schema }),


### PR DESCRIPTION
Follow-up to #35: keep GPT-5 + `web_search`, but route it through the **Vercel AI Gateway** rather than calling OpenAI directly.

- Model id is now the gateway form `openai/gpt-5` (a bare string resolves via the gateway); auth reverts to **`AI_GATEWAY_API_KEY`** — no separate `OPENAI_API_KEY`.
- The `@ai-sdk/openai` `web_search` tool is still attached; the gateway forwards it to the OpenAI model.
- Env docs reverted accordingly (`AI_RESEARCH_MODEL` default is now `openai/gpt-5`).

Tracker-only — no plugin release. `tsc` + `npm run build` pass. Since you already have `AI_GATEWAY_API_KEY` in Vercel, the AI re-check should work right after deploy — the debug modal will show the request/response/sources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)