### PR TITLE
docs(wp-mcp-generator): use the admin-login-link ability, not a hardcoded password

### DIFF
--- a/abilities-generator/skills/wp-mcp-generator/SKILL.md
+++ b/abilities-generator/skills/wp-mcp-generator/SKILL.md
@@ -80,7 +80,10 @@ Run this loop. Do **not** declare done until all three termination conditions ho
   settings, REST routes, AJAX actions, CPTs/taxonomies, shortcodes/blocks, cron, caps, CLI),
   *data stores* (every option key, table + schema, meta key, CPT — **with its load and save
   paths**), and *tasks* (the verbs an admin performs).
-- Then exercise it for real in Playwright (`http://wordpress/`, admin `admin`/`password`).
+- Then exercise it for real in Playwright at `http://wordpress/`. To reach wp-admin, mint a
+  one-time login URL with the `agent-connector-for-wp/create-admin-login-link` ability and open
+  it in the browser — no username/password needed, and it works whatever the site's admin
+  credentials are.
   Diff the database around each action (`tools/db-diff.sh`) to see exactly what each task
   mutates and to catch stores/actions your code read missed. Watch the save requests and
   any client-side state — that is often where a builder's true document format reveals itself.


### PR DESCRIPTION
The `wp-mcp-generator` skill instructed the agent to log into wp-admin in Playwright with `admin` / `password`. Two problems:

1. It assumes a fixed admin password — but the sandbox's admin credentials are configurable (see create-wp-local-dev-agent-sandbox), so `admin`/`password` isn't guaranteed.
2. It's unnecessary: this plugin already exposes **`agent-connector-for-wp/create-admin-login-link`**, which mints a one-time, short-lived URL that logs the browser into wp-admin as the current super-admin.

So the skill now tells the agent to mint a login URL via that ability and open it in Playwright — no username/password needed, and it works regardless of the site's admin password.

Docs-only change to `abilities-generator/skills/wp-mcp-generator/SKILL.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)