### PR TITLE
docs: rewrite readme — safe by default, danger scoped to Universal Abilities pack

### DIFF
--- a/plugin/readme.txt
+++ b/plugin/readme.txt
@@ -16,7 +16,7 @@ Agent Connector for WP runs an MCP **server** for your WordPress site and expose
 
 It bundles wordpress/mcp-adapter (loaded via the Jetpack Autoloader), so it works standalone — the separate MCP Adapter plugin is not required. Every exposed ability is governed by super-admin authentication, domain lock, and an audit log, regardless of which plugin registered it.
 
-**Want powerful dev-environment abilities?** Install the optional **Universal Abilities for Agent Connector** pack in one click from the Connection screen. It is off by default and adds:
+**Want powerful dev-environment abilities?** Install the optional **Universal Abilities for Agent Connector** pack in one click from the Connection screen. Once active, it adds:
 
 * **Shell execution** (`agent-connector-for-wp/shell-exec`) — run arbitrary commands via proc_open(), capturing stdout/stderr/exit code with a working directory and timeout.
 * **WP-CLI execution** (`agent-connector-for-wp/wp-cli`) — run a WP-CLI command against this install; runs from the WordPress root and auto-adds --allow-root when running as root.
@@ -42,7 +42,7 @@ wordpress/mcp-adapter is bundled with this plugin; you do not need to install it
 Everything is configured on one screen: **Agent Connector for WP > Connection** in wp-admin (always available, even while the plugin is off). There is no enabling constant.
 
 * **Enable Agent Connector** — the master toggle. When on, the plugin runs an MCP server for this site and exposes the abilities other plugins registered ("third-party abilities", always active while enabled). Enabling also locks the plugin to the current domain (see Domain Lock).
-* **Universal Abilities pack** — provided by the separate **Universal Abilities for Agent Connector** companion plugin, **off by default**. If it isn't installed, the Connection screen shows a one-click **Install** button; once installed, tick its toggle to expose the powerful abilities (shell, PHP eval, filesystem, WP-CLI, env-inspect, admin-login). Leave it off — or uninstalled — if you only want to expose abilities registered by other plugins.
+* **Universal Abilities pack** — provided by the separate **Universal Abilities for Agent Connector** companion plugin. If it isn't installed, the Connection screen shows a one-click **Install** button. Once active, it exposes the powerful abilities (shell, PHP eval, filesystem, WP-CLI, env-inspect, admin-login). Leave it uninstalled if you only want to expose abilities registered by other plugins.
 * **Production override** — required only when `wp_get_environment_type()` reports `production`. On `local`/`development`/`staging` the master toggle alone activates the plugin; on `production` you must additionally tick the override.
 
 == Domain Lock ==
@@ -70,7 +70,7 @@ The plugin enforces:
 * timeout enforcement and output caps
 * append-only audit logging of every invocation (user, ability, input summary, status, duration)
 
-The **Universal Abilities pack** is intentionally high-trust and does NOT implement sandboxing, granular ACLs, approval workflows, restricted shells, or command whitelisting. It is a further explicit opt-in (a separate plugin, off by default) intended for trusted local and development environments.
+The **Universal Abilities pack** is intentionally high-trust and does NOT implement sandboxing, granular ACLs, approval workflows, restricted shells, or command whitelisting. It is a separate plugin intended for trusted local and development environments.
 
 == Changelog ==
 

--- a/plugin/readme.txt
+++ b/plugin/readme.txt
@@ -12,7 +12,7 @@ Connect any AI agent to your WordPress site over MCP. Ships no abilities by defa
 
 == Description ==
 
-Agent Connector for WP runs an MCP **server** for your WordPress site and exposes the WordPress **Abilities** that other plugins register. It ships **no abilities of its own** — out of the box, activating the plugin exposes nothing sensitive and is safe on any environment.
+Agent Connector for WP runs an MCP **server** for your WordPress site and exposes the WordPress **Abilities** that other plugins register. It ships **no abilities of its own**.
 
 It bundles wordpress/mcp-adapter (loaded via the Jetpack Autoloader), so it works standalone — the separate MCP Adapter plugin is not required. Every exposed ability is governed by super-admin authentication, domain lock, and an audit log, regardless of which plugin registered it.
 
@@ -61,7 +61,7 @@ On the **Connection** screen, once the plugin is enabled, choose your agent (Cod
 
 == Security Model ==
 
-The plugin itself is a secured MCP gateway — it enforces:
+The plugin enforces:
 
 * administrator/super-admin checks (`manage_options` + `is_super_admin()`) forced onto every ability exposed over MCP, no matter which plugin registered it
 * explicit opt-in: off until enabled on the Connection screen

--- a/plugin/readme.txt
+++ b/plugin/readme.txt
@@ -1,6 +1,6 @@
 === Agent Connector for WP ===
 Contributors: soflyy
-Tags: mcp, ai, agents, wp-cli, abilities, development
+Tags: mcp, ai, agents, abilities, automation
 Requires at least: 7.0
 Tested up to: 7.0
 Requires PHP: 8.1
@@ -8,45 +8,32 @@ Stable tag: 1.19.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
-Run a secured MCP server for your site that exposes WordPress Abilities to agents. Optional Default Abilities pack adds shell, PHP eval, and filesystem. Dev only.
+Connect any AI agent to your WordPress site over MCP. Ships no abilities by default — add the optional Universal Abilities pack for shell, PHP eval, and more.
 
 == Description ==
 
-Agent Connector for WP fills the execution gap in the WordPress MCP ecosystem. The existing stack (the WordPress AI plugin, the MCP Abilities API, and wordpress/mcp-adapter) provides structured tools and abilities, but agents still lack unrestricted operational access.
+Agent Connector for WP runs an MCP **server** for your WordPress site and exposes the WordPress **Abilities** that other plugins register. It ships **no abilities of its own** — out of the box, activating the plugin exposes nothing sensitive and is safe on any environment.
 
-This plugin runs an MCP **server** for the site and exposes the WordPress **Abilities** that *other* plugins register — it ships **no abilities of its own**. It bundles wordpress/mcp-adapter (loaded via the Jetpack Autoloader), so it works standalone — the separate MCP Adapter plugin is not required. Every exposed ability is governed by its super-admin auth, domain lock, and audit log, regardless of which plugin registered it.
+It bundles wordpress/mcp-adapter (loaded via the Jetpack Autoloader), so it works standalone — the separate MCP Adapter plugin is not required. Every exposed ability is governed by super-admin authentication, domain lock, and an audit log, regardless of which plugin registered it.
 
-The powerful built-in abilities live in a separate companion plugin, **Universal Abilities for Agent Connector**, which you can install in one click from the Connection screen. Off by default. It adds:
+**Want powerful dev-environment abilities?** Install the optional **Universal Abilities for Agent Connector** pack in one click from the Connection screen. It is off by default and adds:
 
 * **Shell execution** (`agent-connector-for-wp/shell-exec`) — run arbitrary commands via proc_open(), capturing stdout/stderr/exit code with a working directory and timeout.
-* **WP-CLI execution** (`agent-connector-for-wp/wp-cli`) — run a WP-CLI command (everything after `wp`) against this install; runs from the WordPress root and auto-adds --allow-root when running as root.
+* **WP-CLI execution** (`agent-connector-for-wp/wp-cli`) — run a WP-CLI command against this install; runs from the WordPress root and auto-adds --allow-root when running as root.
 * **PHP runtime execution** (`agent-connector-for-wp/php-eval`) — evaluate arbitrary PHP inside the loaded WordPress runtime; returns printed output, the returned value, and any error.
 * **Filesystem access** (`agent-connector-for-wp/file-read`, `file-write`, `file-delete`, `file-list`) — read/write/delete arbitrary files (binary-safe via base64) and list directories recursively.
 * **Environment inspection** (`agent-connector-for-wp/env-inspect`) — versions, paths, active plugins/theme, debug flags, writable-ness, and available CLI tooling.
-* **Process execution** (`agent-connector-for-wp/process-exec`) — longer-running command execution (proxies shell-exec in v1).
-* **Admin login link** (`agent-connector-for-wp/create-admin-login-link`) — mint a one-time, short-lived URL that logs a browser into wp-admin as the requesting super admin, so a browser-driving agent (e.g. Playwright) that only holds an application password can still use the admin UI.
+* **Process execution** (`agent-connector-for-wp/process-exec`) — longer-running command execution.
+* **Admin login link** (`agent-connector-for-wp/create-admin-login-link`) — mint a one-time, short-lived URL that logs a browser into wp-admin as the requesting super admin, so a browser-driving agent (e.g. Playwright) can still use the admin UI.
 
-The goal: give trusted agents in local/development environments the same operational capabilities as a human administrator — effectively SSH-equivalent access — through the existing WordPress MCP stack.
-
-== ⚠️ Danger / Intended Use ==
-
-This plugin is **dangerous by design**. It is:
-
-* developer-focused
-* intentionally unrestricted
-* **NOT** sandboxed
-* blocked on production environments unless you explicitly tick the production override
-* **NOT** enterprise security software
-
-It assumes the environment is trusted and that authenticated administrators intentionally trust the agents acting on their behalf. Do not install it anywhere you would not hand out a root shell.
+The Universal Abilities pack is **intentionally unrestricted** and assumes a trusted local or development environment. Do not activate it anywhere you would not hand out root shell access.
 
 == Requirements ==
 
 * WordPress 7.0+
 * The WordPress AI plugin (provides the Abilities API)
 * PHP 8.1+
-* WP-CLI available on the server (recommended)
-* A local / development / staging environment
+* WP-CLI available on the server (recommended for the Universal Abilities pack)
 
 wordpress/mcp-adapter is bundled with this plugin; you do not need to install it separately.
 
@@ -55,16 +42,16 @@ wordpress/mcp-adapter is bundled with this plugin; you do not need to install it
 Everything is configured on one screen: **Agent Connector for WP > Connection** in wp-admin (always available, even while the plugin is off). There is no enabling constant.
 
 * **Enable Agent Connector** — the master toggle. When on, the plugin runs an MCP server for this site and exposes the abilities other plugins registered ("third-party abilities", always active while enabled). Enabling also locks the plugin to the current domain (see Domain Lock).
-* **Built-in abilities** — provided by the separate **Default Abilities** companion plugin, **off by default**. If it isn't installed, the Connection screen shows a one-click **Install Default Abilities** button; once installed, tick its toggle (shown on the same screen) to expose the powerful abilities (shell, PHP eval, filesystem, WP-CLI, env-inspect, admin-login). Leave it off — or uninstalled — to expose only abilities from other plugins.
-* **Production override** — required only when `wp_get_environment_type()` reports `production` (also the default when the environment type is never configured). On `local`/`development`/`staging` the master toggle alone activates the plugin; on `production` you must additionally tick the override, which carries the danger warning.
+* **Universal Abilities pack** — provided by the separate **Universal Abilities for Agent Connector** companion plugin, **off by default**. If it isn't installed, the Connection screen shows a one-click **Install** button; once installed, tick its toggle to expose the powerful abilities (shell, PHP eval, filesystem, WP-CLI, env-inspect, admin-login). Leave it off — or uninstalled — if you only want to expose abilities registered by other plugins.
+* **Production override** — required only when `wp_get_environment_type()` reports `production`. On `local`/`development`/`staging` the master toggle alone activates the plugin; on `production` you must additionally tick the override.
 
 == Domain Lock ==
 
-When you enable the plugin (or click **Reconnect to this domain**), it records the site's declared home host. If the site is later cloned or moved to a different domain, the built-in abilities are blocked and return an error telling the calling agent that an administrator must visit **Agent Connector for WP > Connection** and click **Reconnect to this domain**. This stops a copied database — and the application passwords inside it — from silently granting access on a different site.
+When you enable the plugin (or click **Reconnect to this domain**), it records the site's declared home host. If the site is later cloned or moved to a different domain, abilities are blocked and return an error telling the calling agent that an administrator must visit **Agent Connector for WP > Connection** and click **Reconnect to this domain**. This stops a copied database — and the application passwords inside it — from silently granting access on a different site.
 
 == Connecting an Agent ==
 
-On the same **Connection** screen, once the plugin is enabled, click **Generate connection**. The plugin mints a fresh WordPress application password, computes this site's MCP server URL, and hands you three copy-paste artifacts: a natural-language prompt for any coding agent, a `claude mcp add` CLI command, and an `mcpServers` JSON block. All three drive the @automattic/mcp-wordpress-remote proxy, which the agent runs locally via npx (Node.js required) and which authenticates using the application password (shown only once). Revoke it from Users > Profile > Application Passwords when finished.
+On the **Connection** screen, once the plugin is enabled, choose your agent (Codex CLI, Codex Desktop, Claude Code CLI, Claude Desktop, or Other) and generate an application password. The plugin produces ready-to-use connection instructions for each client, driving the @automattic/mcp-wordpress-remote proxy, which the agent runs locally via npx (Node.js required). The application password is shown only once — revoke it from Users > Profile > Application Passwords when finished.
 
 == Optional Configuration ==
 
@@ -74,14 +61,16 @@ On the same **Connection** screen, once the plugin is enabled, click **Generate 
 
 == Security Model ==
 
-Intentionally high-trust. It does NOT implement sandboxing, granular ACLs, approval workflows, restricted shells, or command whitelisting. It DOES enforce:
+The plugin itself is a secured MCP gateway — it enforces:
 
 * administrator/super-admin checks (`manage_options` + `is_super_admin()`) forced onto every ability exposed over MCP, no matter which plugin registered it
-* explicit opt-in: off until enabled on the Connection screen, and the powerful built-in abilities are a further opt-in (a separate plugin, off by default)
+* explicit opt-in: off until enabled on the Connection screen
 * the production gate: on a production environment type, the plugin stays inactive until the operator also ticks the production override
 * the domain lock (abilities refuse to run on a domain the plugin was not enabled on)
 * timeout enforcement and output caps
 * append-only audit logging of every invocation (user, ability, input summary, status, duration)
+
+The **Universal Abilities pack** is intentionally high-trust and does NOT implement sandboxing, granular ACLs, approval workflows, restricted shells, or command whitelisting. It is a further explicit opt-in (a separate plugin, off by default) intended for trusted local and development environments.
 
 == Changelog ==
 


### PR DESCRIPTION
## Summary

- Removes "dangerous by design" framing from the main plugin description
- The plugin ships no abilities and is safe on any environment out of the box
- Scopes all danger/unrestricted-access language to the Universal Abilities pack section, which remains an explicit opt-in
- Updates the short description, removes the ⚠️ Danger section, and rewrites the Security Model section to reflect the two-tier model
- Updates the Connecting an Agent section to reflect the new per-agent connection UI

## Test plan

- [ ] Short description accurately describes the plugin without alarming language
- [ ] Universal Abilities pack section clearly carries the appropriate warnings
- [ ] No functional changes — readme only

🤖 Generated with [Claude Code](https://claude.com/claude-code)