### PR TITLE
fix: detect Universal Abilities pack via the tolerant slug matcher (single slug)

### DIFF
--- a/plugin/src/Admin/ConnectionPage.php
+++ b/plugin/src/Admin/ConnectionPage.php
@@ -14,6 +14,7 @@ declare( strict_types=1 );
 
 namespace AgentConnectorForWp\Admin;
 
+use AgentConnectorForWp\Services\PluginDirectory;
 use AgentConnectorForWp\Support\Config;
 use AgentConnectorForWp\Support\Connection;
 use WP_Application_Passwords;
@@ -142,10 +143,7 @@ final class ConnectionPage {
 	}
 
 	private function is_uap_active(): bool {
-		if ( ! function_exists( 'is_plugin_active' ) ) {
-			require_once ABSPATH . 'wp-admin/includes/plugin.php';
-		}
-		return is_plugin_active( 'universal-abilities-plugin/default-abilities-plugin.php' );
+		return PluginDirectory::is_universal_abilities_active();
 	}
 
 	private function pw_available( ?\WP_User $user ): bool {

--- a/plugin/src/Rest/SettingsController.php
+++ b/plugin/src/Rest/SettingsController.php
@@ -596,23 +596,25 @@ final class SettingsController extends WP_REST_Controller {
 			return new WP_Error( 'forbidden', __( 'You do not have permission to install plugins.', 'agent-connector-for-wp' ), array( 'status' => 403 ) );
 		}
 
-		$plugin_file = 'universal-abilities-plugin/default-abilities-plugin.php';
-
 		require_once ABSPATH . 'wp-admin/includes/plugin.php';
 
-		if ( is_plugin_active( $plugin_file ) ) {
+		// Already active — nothing to do.
+		if ( PluginDirectory::is_universal_abilities_active() ) {
 			return new WP_REST_Response( array( 'success' => true, 'uap_active' => true ) );
 		}
 
-		if ( file_exists( WP_PLUGIN_DIR . '/' . $plugin_file ) ) {
-			$result = activate_plugin( $plugin_file, '', false, true );
+		// Installed but inactive — activate the existing copy instead of downloading a duplicate.
+		$existing = PluginDirectory::universal_abilities_file();
+		if ( null !== $existing ) {
+			$result = activate_plugin( $existing, '', false, true );
 			if ( is_wp_error( $result ) ) {
 				return $result;
 			}
 			return new WP_REST_Response( array( 'success' => true, 'uap_active' => true ) );
 		}
 
-		$url = 'https://github.com/soflyy/agent-connector-for-wp/releases/download/universal-abilities-plugin/universal-abilities-plugin.zip';
+		$plugin_file = 'universal-abilities-plugin/default-abilities-plugin.php';
+		$url         = 'https://github.com/soflyy/agent-connector-for-wp/releases/download/universal-abilities-plugin/universal-abilities-plugin.zip';
 
 		require_once ABSPATH . 'wp-admin/includes/file.php';
 		require_once ABSPATH . 'wp-admin/includes/misc.php';
@@ -635,10 +637,7 @@ final class SettingsController extends WP_REST_Controller {
 	}
 
 	private function is_uap_active(): bool {
-		if ( ! function_exists( 'is_plugin_active' ) ) {
-			require_once ABSPATH . 'wp-admin/includes/plugin.php';
-		}
-		return is_plugin_active( 'universal-abilities-plugin/default-abilities-plugin.php' );
+		return PluginDirectory::is_universal_abilities_active();
 	}
 
 	private function pw_available( ?\WP_User $user ): bool {

--- a/plugin/src/Services/PluginDirectory.php
+++ b/plugin/src/Services/PluginDirectory.php
@@ -420,6 +420,29 @@ final class PluginDirectory {
 	}
 
 	/**
+	 * The Universal Abilities companion plugin's folder slug.
+	 */
+	public const UNIVERSAL_ABILITIES_SLUG = 'universal-abilities-plugin';
+
+	/**
+	 * Resolve the Universal Abilities companion plugin's installed file via the
+	 * tolerant slug matcher (so it's found regardless of its main-file name), or
+	 * null when it isn't installed.
+	 */
+	public static function universal_abilities_file(): ?string {
+		return self::installed_file_for_slug( self::UNIVERSAL_ABILITIES_SLUG );
+	}
+
+	/**
+	 * Whether the Universal Abilities companion plugin is installed AND active.
+	 */
+	public static function is_universal_abilities_active(): bool {
+		$file = self::universal_abilities_file();
+
+		return null !== $file && self::is_active( $file );
+	}
+
+	/**
 	 * Resolve a manifest slug to an installed plugin file, tolerating slug format
 	 * differences (full "folder/file.php" path vs bare folder slug).
 	 *


### PR DESCRIPTION
Alternative to #56, scoped to a **single slug** (no legacy `default-abilities-plugin` backwards-compat).

## Problem
The Connection screen shows an **Install** button for the Universal Abilities pack even when it's installed and active, because detection is hardcoded in three places to `is_plugin_active('universal-abilities-plugin/default-abilities-plugin.php')` — a brittle folder + main-file string.

## Fix
- `PluginDirectory::is_universal_abilities_active()` + `universal_abilities_file()` resolve the pack through the existing tolerant matcher (`installed_file_for_slug`) on the current `universal-abilities-plugin` slug — robust to the main-file name, shared by the UI and the install flow.
- The three hardcoded detection sites (`ConnectionPage::is_uap_active`, `SettingsController::is_uap_active`, the early checks in `install_uap`) now go through it.
- `install_uap()` **activates an existing copy** instead of downloading a duplicate; a fresh install still pulls the current release.

Single slug only — no `default-abilities-plugin` legacy matching (per request; not needed).

`php -l` clean on all three files.

Supersedes #56 — close that in favor of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)