### PR TITLE
feat: add search-media ability to the Universal Abilities Pack

### DIFF
--- a/universal-abilities-plugin/README.md
+++ b/universal-abilities-plugin/README.md
@@ -13,6 +13,7 @@ control of the site to an agent over MCP:
 | `agent-connector-for-wp/php-eval` | Evaluate PHP inside the live WordPress runtime. |
 | `agent-connector-for-wp/file-read` · `-write` · `-list` · `-delete` | Filesystem operations. |
 | `agent-connector-for-wp/env-inspect` | Inspect server / environment details. |
+| `agent-connector-for-wp/search-media` | Search the WordPress media library (read-only). |
 | `agent-connector-for-wp/create-admin-login-link` | Mint a one-time admin login link. |
 
 > **Danger.** These abilities are not sandboxed and are **not** for production.

--- a/universal-abilities-plugin/src/Abilities/SearchMediaAbility.php
+++ b/universal-abilities-plugin/src/Abilities/SearchMediaAbility.php
@@ -1,0 +1,151 @@
+<?php
+/**
+ * Ability: agent-connector-for-wp/search-media
+ *
+ * @package AgentConnectorForWp
+ */
+
+declare( strict_types=1 );
+
+namespace AgentConnectorForWp\DefaultAbilities\Abilities;
+
+use AgentConnectorForWp\Services\AuditLogger;
+use AgentConnectorForWp\DefaultAbilities\Services\MediaLibrary;
+use AgentConnectorForWp\Support\Config;
+
+defined( 'ABSPATH' ) || exit;
+
+final class SearchMediaAbility {
+
+	public const NAME = 'agent-connector-for-wp/search-media';
+
+	public static function is_allowed(): bool {
+		return true;
+	}
+
+	/**
+	 * @return array<string,mixed>
+	 */
+	public static function definition(): array {
+		return array(
+			'label'               => 'Search Media',
+			'description'         => 'Searches the WordPress media library and returns matching attachments (id, url, alt, caption, dimensions). Use this to find real images already on the site — a logo, product photos, brand imagery — instead of hardcoding external image URLs. The returned id/url/alt can be set directly on an element image control.',
+			'category'            => 'agent-connector-for-wp',
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'additionalProperties' => false,
+				'properties'           => array(
+					'query'     => array(
+						'type'        => 'string',
+						'description' => 'Optional keyword to search the title, filename, caption, and description.',
+					),
+					'mime_type' => array(
+						'type'        => array( 'string', 'array' ),
+						'items'       => array( 'type' => 'string' ),
+						'default'     => 'image',
+						'description' => 'Filter by MIME type (passed to WP_Query post_mime_type). Defaults to "image" (all image types). Pass a specific type like "image/png", an array like ["image/png","image/jpeg"], a top-level type like "video", or "any" to return all media.',
+					),
+					'limit'     => array(
+						'type'        => 'integer',
+						'minimum'     => 1,
+						'maximum'     => 100,
+						'default'     => 20,
+						'description' => 'Maximum number of items to return.',
+					),
+					'offset'    => array(
+						'type'        => 'integer',
+						'minimum'     => 0,
+						'default'     => 0,
+						'description' => 'Number of items to skip (for pagination).',
+					),
+				),
+			),
+			'output_schema'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'total' => array(
+						'type'        => 'integer',
+						'description' => 'Total items matching the query, ignoring limit/offset.',
+					),
+					'items' => array(
+						'type'        => 'array',
+						'description' => 'The matching media attachments.',
+						'items'       => array(
+							'type'       => 'object',
+							'properties' => array(
+								'id'       => array(
+									'type'        => 'integer',
+									'description' => 'Attachment ID. Set this as the image control id to use the library asset.',
+								),
+								'url'      => array(
+									'type'        => 'string',
+									'description' => 'Full-size URL of the attachment.',
+								),
+								'alt'      => array(
+									'type'        => 'string',
+									'description' => 'Alt text stored on the attachment.',
+								),
+								'caption'  => array(
+									'type'        => 'string',
+									'description' => 'Attachment caption.',
+								),
+								'filename' => array(
+									'type'        => 'string',
+									'description' => 'Original file name.',
+								),
+								'mime'     => array(
+									'type'        => 'string',
+									'description' => 'MIME type, e.g. "image/jpeg".',
+								),
+								'width'    => array(
+									'type'        => 'integer',
+									'description' => 'Intrinsic width in pixels (0 if unknown).',
+								),
+								'height'   => array(
+									'type'        => 'integer',
+									'description' => 'Intrinsic height in pixels (0 if unknown).',
+								),
+							),
+						),
+					),
+				),
+			),
+			'execute_callback'    => AuditLogger::wrap(
+				self::NAME,
+				array( self::class, 'execute' ),
+				array( self::class, 'summarize' )
+			),
+			'permission_callback' => static function (): bool {
+				return Config::has_admin_access();
+			},
+			'meta'                => array(
+				'mcp'          => array( 'public' => true ),
+				'annotations'  => array( 'readonly' => true ),
+				'show_in_rest' => true,
+			),
+		);
+	}
+
+	/**
+	 * @param array<string,mixed> $input
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	public static function execute( array $input ) {
+		return ( new MediaLibrary() )->search( $input );
+	}
+
+	/**
+	 * @param array<string,mixed> $input
+	 * @return array<string,mixed>
+	 */
+	public static function summarize( array $input ): array {
+		$summary = array();
+		if ( isset( $input['query'] ) ) {
+			$summary['query'] = (string) $input['query'];
+		}
+		if ( isset( $input['mime_type'] ) ) {
+			$summary['mime_type'] = $input['mime_type'];
+		}
+		return $summary;
+	}
+}

--- a/universal-abilities-plugin/src/Plugin.php
+++ b/universal-abilities-plugin/src/Plugin.php
@@ -17,6 +17,7 @@ use AgentConnectorForWp\DefaultAbilities\Abilities\FileReadAbility;
 use AgentConnectorForWp\DefaultAbilities\Abilities\FileWriteAbility;
 use AgentConnectorForWp\DefaultAbilities\Abilities\PhpEvalAbility;
 use AgentConnectorForWp\DefaultAbilities\Abilities\ProcessExecAbility;
+use AgentConnectorForWp\DefaultAbilities\Abilities\SearchMediaAbility;
 use AgentConnectorForWp\DefaultAbilities\Abilities\ShellAbility;
 use AgentConnectorForWp\DefaultAbilities\Abilities\WpCliAbility;
 use AgentConnectorForWp\DefaultAbilities\Services\AdminLoginLink;
@@ -46,6 +47,7 @@ final class Plugin {
 		FileWriteAbility::class,
 		FileListAbility::class,
 		FileDeleteAbility::class,
+		SearchMediaAbility::class,
 		AdminLoginAbility::class,
 	);
 

--- a/universal-abilities-plugin/src/Services/MediaLibrary.php
+++ b/universal-abilities-plugin/src/Services/MediaLibrary.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Read-only access to the WordPress media library.
+ *
+ * @package AgentConnectorForWp
+ */
+
+declare( strict_types=1 );
+
+namespace AgentConnectorForWp\DefaultAbilities\Services;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Searches attachments and returns lean, agent-friendly results: the shape an
+ * image control consumes (id, url, alt) plus a little metadata. Deliberately
+ * excludes the heavy srcset/sizes blob.
+ */
+final class MediaLibrary {
+
+	/**
+	 * Search the media library for attachments.
+	 *
+	 * @param array{query?: string, mime_type?: string|string[], limit?: int, offset?: int} $input
+	 * @return array{total: int, items: array<int, array{id: int, url: string, alt: string, caption: string, filename: string, mime: string, width: int, height: int}>}
+	 */
+	public function search( array $input ): array {
+		$query_args = array(
+			'post_type'              => 'attachment',
+			'post_status'            => 'inherit',
+			'posts_per_page'         => min( 100, max( 1, (int) ( $input['limit'] ?? 20 ) ) ),
+			'offset'                 => max( 0, (int) ( $input['offset'] ?? 0 ) ),
+			'no_found_rows'          => false,
+			'update_post_term_cache' => false,
+			'orderby'                => 'date',
+			'order'                  => 'DESC',
+		);
+
+		if ( ! empty( $input['query'] ) ) {
+			$query_args['s'] = (string) $input['query'];
+		}
+
+		// Default to images; a literal "any" (or empty) opts out of the mime filter.
+		// WP_Query treats "image" as image/*, and accepts a string or an array.
+		$mime = $input['mime_type'] ?? 'image';
+		if ( 'any' !== $mime && '' !== $mime && array() !== $mime ) {
+			$query_args['post_mime_type'] = $mime;
+		}
+
+		$query = new \WP_Query( $query_args );
+
+		$items = array_map(
+			static function ( $post ): array {
+				$meta   = wp_get_attachment_metadata( (int) $post->ID );
+				$width  = is_array( $meta ) && isset( $meta['width'] ) ? (int) $meta['width'] : 0;
+				$height = is_array( $meta ) && isset( $meta['height'] ) ? (int) $meta['height'] : 0;
+
+				return array(
+					'id'       => (int) $post->ID,
+					'url'      => (string) wp_get_attachment_url( $post->ID ),
+					'alt'      => (string) get_post_meta( $post->ID, '_wp_attachment_image_alt', true ),
+					'caption'  => (string) $post->post_excerpt,
+					'filename' => (string) wp_basename( (string) get_attached_file( $post->ID ) ),
+					'mime'     => (string) $post->post_mime_type,
+					'width'    => $width,
+					'height'   => $height,
+				);
+			},
+			$query->posts
+		);
+
+		return array(
+			'total' => (int) $query->found_posts,
+			'items' => $items,
+		);
+	}
+}


### PR DESCRIPTION
## Summary

Ports the read-only `search-media` MCP ability from [soflyy/breakdance#9490](https://github.com/soflyy/breakdance/pull/9490) into the Universal Abilities Pack, so **any** WordPress site running Agent Connector can search its media library over MCP — not just Breakdance sites.

Before this, the pack exposed powerful operational abilities (shell, PHP eval, filesystem, WP-CLI) but had no first-class, read-only way for an agent to discover real images already on the site. Agents needing an image had to hardcode an external URL rather than reuse the site's own logo/product photos or supply a proper attachment `id`. `search-media` closes that gap.

## Changes

- **New** `src/Abilities/SearchMediaAbility.php` — registers `agent-connector-for-wp/search-media`. Read-only, admin-gated, always registered. Mirrors the `FileReadAbility` pattern: optional `query` keyword, `mime_type` filter (string or array; **defaults to `image`**, `"any"` opts out), and `limit`/`offset` pagination. Wrapped by the main plugin's `AuditLogger`; `readonly` annotation + `Config::has_admin_access()` permission callback.
- **New** `src/Services/MediaLibrary.php` — the search logic. Queries attachments (`post_type => attachment`, `post_status => inherit`, `no_found_rows => false` for an accurate `total`) and shapes lean results (`id`, `url`, `alt`, `caption`, `filename`, `mime`, `width`, `height`) in the shape an image control consumes — deliberately excluding the heavy srcset/`sizes` blob. Clamps `limit` (0→1, 999→100) and passes `offset` through.
- **`src/Plugin.php`** — adds `SearchMediaAbility` to the registered-abilities list.
- **`README.md`** — documents the new ability in the abilities table.

## Verification

Exercised live against the sandbox WordPress via the MCP adapter (plugin symlinked into the install):

- `php -l` clean on all changed files.
- Ability discovered by `mcp-adapter-discover-abilities`.
- Sideloaded a test PNG (alt "Company logo alt"), then:
  - `{query: "logo"}` → `total: 1` with the full output shape (`id`, `url`, `alt`, `caption:""`, `filename`, `mime: image/png`, `width`, `height`).
  - `{mime_type: "video"}` → `total: 0` (default/explicit image filter excludes it).
  - `{mime_type: "any"}` → returns the attachment (mime opt-out path).
  - `{limit: 999}` → rejected by the adapter's schema validation (max 100); the service-level clamp is a belt-and-suspenders backstop.
- Cleaned up the test attachment afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)