### PR TITLE
feat: versioned releases + host-managed updates for Universal Abilities

### DIFF
--- a/.github/workflows/default-abilities-release.yml
+++ b/.github/workflows/default-abilities-release.yml
@@ -1,15 +1,27 @@
-name: Release Default Abilities plugin
+name: Release Universal Abilities plugin
 
-# Builds the Default Abilities companion plugin (universal-abilities-plugin/) as a
-# standalone WordPress plugin zip and publishes it as the asset of a stable,
-# non-"latest" release tagged `universal-abilities-plugin`. That gives the zip a
-# permanent URL that the main plugin's one-click installer (Connection screen)
-# downloads from:
-#   https://github.com/<owner>/<repo>/releases/download/universal-abilities-plugin/universal-abilities-plugin.zip
+# Builds the Universal Abilities companion plugin (universal-abilities-plugin/) as
+# a standalone WordPress plugin zip and publishes a VERSIONED release, then
+# refreshes a small stable manifest the main plugin reads for install + updates.
 #
-# The plugin ships no Composer dependencies — it reuses the main plugin's bundled
-# infrastructure at runtime — so the build is just stage + zip. The version is
-# stamped into the built zip from the plugin header; nothing is committed back.
+# Versioning mirrors the MAIN plugin (commit-back), not the ability packs
+# (stamp-only): Universal Abilities is a singleton, so one release = one bump
+# commit — the "many commits" problem that pushed packs to stamp-only doesn't
+# apply, and a user-facing plugin should carry its real version in its header.
+#
+# Per release:
+#   * tag    : universal-abilities-plugin-vX.Y.Z
+#   * release: same tag, asset universal-abilities-plugin.zip  (never clobbered)
+# The bump level comes from the merged PR title (Conventional Commits), or the
+# workflow_dispatch "bump" input.
+#
+# The install/update pointer is a one-object manifest published as the asset
+# index.json of a stable, non-"latest" release tagged `universal-abilities-index`:
+#   https://github.com/<owner>/<repo>/releases/download/universal-abilities-index/index.json
+# It always names the latest VERSIONED zip. Kept separate from pack-index so the
+# two release workflows never contend over one asset. The plugin ships no Composer
+# dependencies (it reuses the main plugin's bundled infrastructure), so the build
+# is just stage + zip.
 on:
   push:
     branches: [master]
@@ -17,48 +29,148 @@ on:
       - 'universal-abilities-plugin/**'
       - '.github/workflows/default-abilities-release.yml'
   workflow_dispatch:
+    inputs:
+      bump:
+        description: 'Force bump level'
+        default: 'auto'
+        type: choice
+        options: [auto, patch, minor, major]
 
+# Push the bump commit + tag, create releases, and read the merged PR title.
 permissions:
   contents: write
+  pull-requests: read
 
 concurrency:
-  group: default-abilities-release
+  group: universal-abilities-release
   cancel-in-progress: false
 
 env:
   PLUGIN_SLUG: universal-abilities-plugin
+  MAIN_FILE: universal-abilities-plugin/default-abilities-plugin.php
+  INDEX_TAG: universal-abilities-index
 
 jobs:
   release:
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ github.token }}
+    # Never react to our own "[skip ci]" version-bump commit.
+    if: ${{ !contains(github.event.head_commit.message, '[skip ci]') }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # full history + tags, needed to compute the next version
 
-      - name: Stage plugin files
+      - name: Determine next version
+        id: ver
+        run: |
+          set -euo pipefail
+
+          latest=$(git tag --list "${PLUGIN_SLUG}-v*" --sort=-v:refname | head -1 || true)
+
+          # No tag yet → seed the series at the current header version (first
+          # release establishes the baseline without a bump).
+          if [ -z "$latest" ]; then
+            header=$(grep -m1 -E "^[[:space:]]*\*[[:space:]]*Version:" "$MAIN_FILE" \
+              | sed -E "s/^[[:space:]]*\*[[:space:]]*Version:[[:space:]]*//; s/[[:space:]]*$//")
+            new="${header:-1.0.0}"
+            echo "First release — baseline from header: $new"
+          else
+            title=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls" --jq '.[0].title' 2>/dev/null || true)
+            if [ -z "${title}" ] || [ "${title}" = "null" ]; then
+              title=$(git log -1 --pretty=%s)
+            fi
+            body=$(git log -1 --pretty=%b)
+
+            level="${{ github.event.inputs.bump || 'auto' }}"
+            if [ "$level" = "auto" ]; then
+              if printf '%s' "$title" | grep -qE '^[a-zA-Z]+(\(.+\))?!:' || printf '%s' "$body" | grep -qE 'BREAKING[ -]CHANGE'; then
+                level="major"
+              elif printf '%s' "$title" | grep -qiE '^fix(\(.+\))?:'; then
+                level="patch"
+              else
+                level="minor"
+              fi
+            fi
+            echo "Bump: $level"
+
+            ver=${latest#${PLUGIN_SLUG}-v}
+            IFS='.' read -r MA MI PA <<< "$ver"
+            case "$level" in
+              major) MA=$((MA + 1)); MI=0; PA=0 ;;
+              minor) MI=$((MI + 1)); PA=0 ;;
+              patch) PA=$((PA + 1)) ;;
+            esac
+            new="${MA}.${MI}.${PA}"
+          fi
+
+          echo "New version: $new"
+          {
+            echo "version=$new"
+            echo "tag=${PLUGIN_SLUG}-v$new"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Sync version into source
+        run: |
+          set -euo pipefail
+          V="${{ steps.ver.outputs.version }}"
+          sed -i -E "s/^( \* Version:[[:space:]]+).*/\1${V}/" "$MAIN_FILE"
+          sed -i -E "s/(define\( 'AGENT_CONNECTOR_DEFAULT_ABILITIES_VERSION', ')[^']*(' \);)/\1${V}\2/" "$MAIN_FILE"
+          echo "---- changed lines ----"
+          grep -nE "Version:|AGENT_CONNECTOR_DEFAULT_ABILITIES_VERSION" "$MAIN_FILE"
+
+      - name: Commit, tag, and push
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add "$MAIN_FILE"
+          # Nothing to commit on a first release where the header already matches;
+          # still tag it so the series has a baseline.
+          git commit -m "chore(release): ${{ steps.ver.outputs.tag }} [skip ci]" || echo "No header change to commit."
+          git tag -a "${{ steps.ver.outputs.tag }}" -m "${{ steps.ver.outputs.tag }}"
+          git push origin "HEAD:${GITHUB_REF_NAME}"
+          git push origin "${{ steps.ver.outputs.tag }}"
+
+      - name: Build plugin zip
         run: |
           set -euo pipefail
           rm -rf dist && mkdir -p "dist/${PLUGIN_SLUG}"
           rsync -a --delete \
             --exclude='dist' --exclude='vendor' --exclude='node_modules' --exclude='.git' \
             "${PLUGIN_SLUG}/" "dist/${PLUGIN_SLUG}/"
-
-      - name: Create zip
-        run: |
-          set -euo pipefail
           cd dist && zip -rq "${PLUGIN_SLUG}.zip" "${PLUGIN_SLUG}"
 
-      - name: Publish to the stable universal-abilities-plugin release
+      - name: Publish the versioned release
         run: |
           set -euo pipefail
-          notes="The Default Abilities pack for Agent Connector for WP. Install in one click from wp-admin → Agent Connector for WP → Connection, or download the zip below."
-          if ! gh release view "${PLUGIN_SLUG}" >/dev/null 2>&1; then
-            gh release create "${PLUGIN_SLUG}" "dist/${PLUGIN_SLUG}.zip" \
-              --title "Default Abilities plugin" \
-              --notes "$notes" \
+          notes="Universal Abilities for Agent Connector — version ${{ steps.ver.outputs.version }}. Install in one click from wp-admin → Agent Connector → Settings, or download the zip below."
+          gh release create "${{ steps.ver.outputs.tag }}" "dist/${PLUGIN_SLUG}.zip" \
+            --title "${{ steps.ver.outputs.tag }}" \
+            --notes "$notes" \
+            --latest=false
+
+      - name: Refresh the stable install/update manifest
+        run: |
+          set -euo pipefail
+          repo="${GITHUB_REPOSITORY}"
+          name=$(grep -m1 -E "^[[:space:]]*\*[[:space:]]*Plugin Name:" "$MAIN_FILE" \
+            | sed -E "s/^[[:space:]]*\*[[:space:]]*Plugin Name:[[:space:]]*//; s/[[:space:]]*$//")
+          dl="https://github.com/${repo}/releases/download/${{ steps.ver.outputs.tag }}/${PLUGIN_SLUG}.zip"
+          src="https://github.com/${repo}/tree/master/${PLUGIN_SLUG}"
+
+          jq -nc --arg slug "$PLUGIN_SLUG" --arg version "${{ steps.ver.outputs.version }}" \
+            --arg dl "$dl" --arg name "$name" --arg src "$src" \
+            '{slug:$slug, version:$version, download_url:$dl, name:$name, source_url:$src}' > index.json
+          echo "---- index.json ----"; cat index.json
+
+          if ! gh release view "$INDEX_TAG" >/dev/null 2>&1; then
+            gh release create "$INDEX_TAG" index.json \
+              --title "Universal Abilities index" \
+              --notes "Auto-generated manifest pointing at the latest Universal Abilities release. Consumed by the Agent Connector plugin for install + updates. Do not edit by hand." \
               --latest=false
           else
-            gh release upload "${PLUGIN_SLUG}" "dist/${PLUGIN_SLUG}.zip" --clobber
+            gh release upload "$INDEX_TAG" index.json --clobber
           fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,9 +13,14 @@ Read [`CONTRIBUTING.md`](CONTRIBUTING.md) before opening a PR.
 | `bin/` | Dev scripts (`install.sh` symlinks `plugin/` + `universal-abilities-plugin/` into a WP install). | — |
 
 Each subproject has its own README/CONTRIBUTING. The PR-title release automation
-below applies **only** to `plugin/`; `universal-abilities-plugin/` is published by
-its own workflow (`.github/workflows/default-abilities-release.yml`) to the
-stable `universal-abilities-plugin` release on any change under that directory.
+below applies to both `plugin/` and `universal-abilities-plugin/` — the latter via
+its own workflow (`.github/workflows/default-abilities-release.yml`), which uses
+the same commit-back versioning (PR title → bump → tag `universal-abilities-plugin-vX.Y.Z`
+→ versioned release, never clobbered) and refreshes a stable
+`universal-abilities-index` manifest that the main plugin reads for one-click
+install and updates. Ability packs (`ability-packs/`) use stamp-only versioning
+instead (see `ability-packs-release.yml`). All three are consumed at runtime by
+the main plugin's updater — nothing self-updates.
 
 ## PR / commit titles drive releases
 

--- a/plugin/src/Rest/SettingsController.php
+++ b/plugin/src/Rest/SettingsController.php
@@ -652,8 +652,15 @@ final class SettingsController extends WP_REST_Controller {
 			return new WP_REST_Response( array( 'success' => true, 'uap_active' => true ) );
 		}
 
-		$plugin_file = 'universal-abilities-plugin/default-abilities-plugin.php';
-		$url         = 'https://github.com/soflyy/agent-connector-for-wp/releases/download/universal-abilities-plugin/universal-abilities-plugin.zip';
+		// Resolve the latest versioned zip from the Universal Abilities manifest —
+		// the same source the updater uses, so first-install and updates share one
+		// source of truth (no hardcoded "latest" URL to clobber).
+		$entry = PluginDirectory::universal_abilities_entry();
+		$url   = null !== $entry ? (string) ( $entry['download_url'] ?? '' ) : '';
+
+		if ( '' === $url || ! self::is_pack_download_allowed( $url ) ) {
+			return new WP_Error( 'no_source', __( 'Could not find a download URL for Universal Abilities. Please try again later or install it manually.', 'agent-connector-for-wp' ), array( 'status' => 500 ) );
+		}
 
 		require_once ABSPATH . 'wp-admin/includes/file.php';
 		require_once ABSPATH . 'wp-admin/includes/misc.php';
@@ -663,11 +670,18 @@ final class SettingsController extends WP_REST_Controller {
 			return new WP_Error( 'fs_unavailable', __( 'Direct filesystem access is not available on this server.', 'agent-connector-for-wp' ), array( 'status' => 500 ) );
 		}
 
-		$upgrader = new \Plugin_Upgrader( new \Automatic_Upgrader_Skin() );
+		$upgrader  = new \Plugin_Upgrader( new \Automatic_Upgrader_Skin() );
 		$installed = $upgrader->install( $url );
 
 		if ( is_wp_error( $installed ) || true !== $installed ) {
 			return new WP_Error( 'install_failed', __( 'Could not install Universal Abilities. Please try installing it manually.', 'agent-connector-for-wp' ), array( 'status' => 500 ) );
+		}
+
+		// Prefer the freshly-installed file the upgrader reports; fall back to the
+		// known main-file path (its folder slug is fixed by the release zip).
+		$plugin_file = (string) $upgrader->plugin_info();
+		if ( '' === $plugin_file ) {
+			$plugin_file = (string) ( PluginDirectory::universal_abilities_file() ?? 'universal-abilities-plugin/default-abilities-plugin.php' );
 		}
 
 		activate_plugin( $plugin_file, '', false, true );

--- a/plugin/src/Services/PackUpdater.php
+++ b/plugin/src/Services/PackUpdater.php
@@ -147,7 +147,14 @@ final class PackUpdater {
 	}
 
 	/**
-	 * Directory entries keyed by ability_pack_slug (cache-aware, manifest-backed).
+	 * Update sources keyed by folder slug (cache-aware, manifest-backed).
+	 *
+	 * Combines two manifests, both consumed the same way by inject_updates():
+	 *   - the ability-pack manifest (many entries, keyed by ability_pack_slug), and
+	 *   - the Universal Abilities manifest (one entry). Universal Abilities carries
+	 *     the same "Agent Connector" marker header as a pack, so installed_packs()
+	 *     already detects it; adding its manifest entry here is all that's needed
+	 *     for it to update through the very same path.
 	 *
 	 * @return array<string,array<string,string>>
 	 */
@@ -159,6 +166,11 @@ final class PackUpdater {
 			if ( '' !== $slug ) {
 				$by_slug[ $slug ] = $entry;
 			}
+		}
+
+		$uap = PluginDirectory::universal_abilities_entry();
+		if ( null !== $uap ) {
+			$by_slug[ PluginDirectory::UNIVERSAL_ABILITIES_SLUG ] = $uap;
 		}
 
 		return $by_slug;

--- a/plugin/src/Services/PluginDirectory.php
+++ b/plugin/src/Services/PluginDirectory.php
@@ -39,11 +39,28 @@ final class PluginDirectory {
 	public const DEFAULT_PACK_INDEX_URL = 'https://github.com/soflyy/agent-connector-for-wp/releases/download/pack-index/index.json';
 
 	/**
+	 * Default Universal Abilities manifest URL — the stable
+	 * `universal-abilities-index` release asset, refreshed by
+	 * default-abilities-release.yml on every UAP release. A one-object JSON
+	 * ({slug, version, download_url, …}) pointing at the latest *versioned* zip.
+	 *
+	 * Kept as its own manifest (not merged into pack-index) so the two release
+	 * workflows never contend over a single asset. Override with the
+	 * `agent_connector_for_wp_universal_abilities_index_url` filter.
+	 */
+	public const DEFAULT_UNIVERSAL_ABILITIES_INDEX_URL = 'https://github.com/soflyy/agent-connector-for-wp/releases/download/universal-abilities-index/index.json';
+
+	/**
 	 * Transient holding the last successfully fetched + normalized manifest.
 	 *
 	 * @var array<string,mixed>|false
 	 */
 	public const CACHE_KEY = 'agent_connector_for_wp_directory_cache';
+
+	/**
+	 * Transient holding the last good Universal Abilities manifest entry.
+	 */
+	public const UNIVERSAL_ABILITIES_CACHE_KEY = 'agent_connector_for_wp_uap_index_cache';
 
 	/**
 	 * Transient lifetime: 12 hours.
@@ -142,20 +159,121 @@ final class PluginDirectory {
 	}
 
 	/**
-	 * Drop the cached manifest so the next read refetches.
+	 * Drop the cached manifests so the next read refetches.
 	 */
 	public static function clear_cache(): void {
 		delete_transient( self::CACHE_KEY );
+		delete_transient( self::UNIVERSAL_ABILITIES_CACHE_KEY );
 	}
 
 	/**
-	 * Fetch + decode + normalize the manifest from the network.
+	 * The Universal Abilities manifest URL, after the override filter.
+	 */
+	public static function universal_abilities_index_url(): string {
+		/**
+		 * Filters the URL of the Universal Abilities manifest.
+		 *
+		 * @param string $url Default manifest URL.
+		 */
+		return (string) apply_filters(
+			'agent_connector_for_wp_universal_abilities_index_url',
+			self::DEFAULT_UNIVERSAL_ABILITIES_INDEX_URL
+		);
+	}
+
+	/**
+	 * The latest published Universal Abilities release, as
+	 * {slug, version, download_url, name, source_url}, or null when the manifest
+	 * is unreachable and nothing usable is cached.
+	 *
+	 * Cached in its own transient with the same best-effort, never-fatal policy as
+	 * the ability-pack manifest: a network/parse failure falls back to the last
+	 * good copy.
+	 *
+	 * @param bool $force When true, bypass the cache and refetch from the network.
+	 *
+	 * @return array{slug:string,version:string,download_url:string,name:string,source_url:string}|null
+	 */
+	public static function universal_abilities_entry( bool $force = false ): ?array {
+		if ( ! $force ) {
+			$cached = get_transient( self::UNIVERSAL_ABILITIES_CACHE_KEY );
+			if ( is_array( $cached ) ) {
+				return $cached;
+			}
+		}
+
+		$entry = self::normalize_universal_abilities_entry(
+			self::remote_json( self::universal_abilities_index_url() )
+		);
+
+		if ( null !== $entry ) {
+			set_transient( self::UNIVERSAL_ABILITIES_CACHE_KEY, $entry, self::CACHE_TTL );
+			return $entry;
+		}
+
+		// Network/parse failed — fall back to any (possibly stale) cached copy.
+		$cached = get_transient( self::UNIVERSAL_ABILITIES_CACHE_KEY );
+		return is_array( $cached ) ? $cached : null;
+	}
+
+	/**
+	 * Validate + normalize the Universal Abilities manifest object, or null when
+	 * it lacks the fields needed to offer an update (version + download URL).
+	 *
+	 * @param mixed $decoded Decoded JSON.
+	 *
+	 * @return array{slug:string,version:string,download_url:string,name:string,source_url:string}|null
+	 */
+	private static function normalize_universal_abilities_entry( $decoded ): ?array {
+		if ( ! is_array( $decoded ) ) {
+			return null;
+		}
+
+		$str = static function ( $value ): string {
+			return is_string( $value ) ? trim( $value ) : '';
+		};
+
+		$version      = $str( $decoded['version'] ?? '' );
+		$download_url = $str( $decoded['download_url'] ?? '' );
+
+		if ( '' === $version || '' === $download_url ) {
+			return null;
+		}
+
+		$slug = $str( $decoded['slug'] ?? '' );
+
+		return array(
+			'slug'         => '' !== $slug ? $slug : self::UNIVERSAL_ABILITIES_SLUG,
+			'version'      => $version,
+			'download_url' => $download_url,
+			'name'         => $str( $decoded['name'] ?? '' ),
+			'source_url'   => $str( $decoded['source_url'] ?? '' ),
+		);
+	}
+
+	/**
+	 * Fetch + decode + normalize the ability-pack manifest from the network.
 	 *
 	 * @param string $url Manifest URL.
 	 *
 	 * @return array{entries:array<int,array<string,string>>}|null Normalized entries, or null on any failure.
 	 */
 	private static function fetch( string $url ): ?array {
+		$decoded = self::remote_json( $url );
+
+		return null === $decoded ? null : self::normalize( $decoded );
+	}
+
+	/**
+	 * GET a URL and decode it as JSON, or null on any network / HTTP / parse
+	 * failure. Shared by the ability-pack manifest and the Universal Abilities
+	 * manifest fetchers.
+	 *
+	 * @param string $url URL to fetch.
+	 *
+	 * @return mixed Decoded JSON (array/scalar) on success, or null on failure.
+	 */
+	private static function remote_json( string $url ) {
 		if ( '' === $url || ! function_exists( 'wp_remote_get' ) ) {
 			return null;
 		}
@@ -187,7 +305,7 @@ final class PluginDirectory {
 			return null;
 		}
 
-		return self::normalize( $decoded );
+		return $decoded;
 	}
 
 	/**


### PR DESCRIPTION
## Why

Universal Abilities had **no update path**. It published to a single stable tag that got clobbered every release, its header version never changed, and it wasn't in any manifest — so once installed, a site would never see a new version. Meanwhile the plugin was already *detected* as an ability pack by the runtime (it carries the `Agent Connector` marker header and `PackUpdater` finds it), it just had nothing to compare against.

This closes that gap and brings Universal Abilities up to the same standard as the main plugin and ability packs — **with all updater logic living in the main Agent Connector plugin**, none in the pack.

## What changed

### Release workflow (`default-abilities-release.yml`, rewritten)
- **Commit-back versioning, like the main plugin** (not stamp-only like packs). Universal Abilities is a *singleton*, so one release = one bump commit — the "many commits" problem that pushed packs to stamp-only doesn't apply, and a user-facing plugin should carry its real version in its header. PR title (Conventional Commits) or a `workflow_dispatch` input decides the bump; the workflow bumps the header, commits `[skip ci]` (with the loop guard), tags `universal-abilities-plugin-vX.Y.Z`, and publishes a **versioned** release. **Nothing is clobbered** — every version stays downloadable at its tag.
- Refreshes a **separate stable manifest** published as `universal-abilities-index/index.json` — a one-object JSON naming the latest versioned zip. Kept apart from `pack-index` so the two release workflows never contend over a single asset.
- First release seeds the series from the current header (`1.0.0`) without a bump, establishing the baseline tag.

### Runtime (main plugin only)
- **`PluginDirectory`** — reads + caches the UAP manifest via a new `universal_abilities_entry()`, reusing the existing best-effort fetch (extracted into a shared `remote_json()` helper) with the same 12h cache and stale-fallback-on-failure policy. A dedicated transient + override filter (`agent_connector_for_wp_universal_abilities_index_url`).
- **`PackUpdater`** — injects the UAP manifest entry into the *same* `update_plugins` path it already uses for packs. No new update logic; UAP was already detected as installed.
- **`SettingsController::install_uap()`** — reads the manifest for the latest versioned `download_url` instead of the old hardcoded stable URL, so first-install and updates share one source of truth. Download host is still allowlist-checked.

### Docs
- `CLAUDE.md` updated to describe the new UAP release model and the singleton-commit-back vs. many-packs-stamp-only split.

## Why two versioning styles across the repo (for reviewers)
- **Main plugin & Universal Abilities → commit-back**: one canonical, user-facing artifact each; storing the real version in the header is honest, and one release = one commit is fine.
- **Ability packs → stamp-only** (`0.0.0-dev` placeholder, version from tags): many packs released independently, so commit-back would flood `master` with bump commits. The tag series is the version record instead.

## Verification (live sandbox, UAP installed at 1.0.0)
Mocked the manifest via `pre_http_request` and exercised the real code path:
- Manifest **1.1.0 > installed 1.0.0** → update offered in the `update_plugins` transient with the correct versioned package URL.
- Manifest **== installed** → listed under `no_update`, not offered.
- Manifest **unreachable** → `universal_abilities_entry()` returns null, no update offered, no crash.

No behavior change ships until the first run of the rewritten workflow publishes a `universal-abilities-index` manifest; until then `universal_abilities_entry()` simply returns null and install/update fall back cleanly (install returns a friendly "no source" error rather than the old hardcoded URL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)