### PR TITLE
fix: harden the manifest updater so it can never break WordPress

### DIFF
--- a/plugin/src/Services/PackUpdater.php
+++ b/plugin/src/Services/PackUpdater.php
@@ -32,6 +32,12 @@ final class PackUpdater {
 	/** Plugin header naming the host plugin a pack extends. */
 	private const TARGET_HEADER = 'Agent Connector Target';
 
+	/**
+	 * Option remembering the WordPress `last_checked` timestamp we last refreshed
+	 * our manifests against, so we refetch exactly once per real WP update check.
+	 */
+	private const SYNC_OPTION = 'agent_connector_for_wp_manifest_synced_checked';
+
 	public function register(): void {
 		add_filter( 'extra_plugin_headers', array( $this, 'declare_headers' ) );
 		add_filter( 'pre_set_site_transient_update_plugins', array( $this, 'inject_updates' ) );
@@ -62,6 +68,12 @@ final class PackUpdater {
 	/**
 	 * Inject available pack updates into the update_plugins transient.
 	 *
+	 * This runs inside WordPress's own update-check flow (the
+	 * pre_set_site_transient_update_plugins filter). It must NEVER break that
+	 * flow: any error is swallowed and the transient is handed back untouched, so
+	 * a bug or a bad network response here can only ever result in "no update
+	 * offered", never a broken Plugins screen or a failed core update check.
+	 *
 	 * @param mixed $transient The update_plugins site transient (object) or empty.
 	 *
 	 * @return mixed
@@ -71,12 +83,34 @@ final class PackUpdater {
 			return $transient;
 		}
 
+		try {
+			return $this->do_inject( $transient );
+		} catch ( \Throwable $e ) {
+			if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+				error_log( 'Agent Connector pack updater skipped: ' . $e->getMessage() );
+			}
+			return $transient; // Hand WordPress back exactly what it gave us.
+		}
+	}
+
+	/**
+	 * The actual injection, wrapped by inject_updates() so nothing it does can
+	 * escape into WordPress's update flow.
+	 *
+	 * @param object $transient The update_plugins site transient.
+	 *
+	 * @return object
+	 */
+	private function do_inject( $transient ) {
 		$packs = $this->installed_packs();
 		if ( empty( $packs ) ) {
 			return $transient;
 		}
 
-		$by_slug = $this->entries_by_slug();
+		// Only hit the network when WordPress itself just ran a real update check
+		// (scheduled cron or a manual "Check Again"); otherwise serve cache.
+		$by_slug = $this->entries_by_slug( $this->should_refresh( $transient ) );
 		if ( empty( $by_slug ) ) {
 			return $transient;
 		}
@@ -156,10 +190,13 @@ final class PackUpdater {
 	 *     already detects it; adding its manifest entry here is all that's needed
 	 *     for it to update through the very same path.
 	 *
+	 * @param bool $force When true, refetch the manifests from the network
+	 *                    (bypassing the cache). Otherwise serve cache.
+	 *
 	 * @return array<string,array<string,string>>
 	 */
-	private function entries_by_slug(): array {
-		$result  = PluginDirectory::get();
+	private function entries_by_slug( bool $force = false ): array {
+		$result  = PluginDirectory::get( $force );
 		$by_slug = array();
 		foreach ( (array) $result['entries'] as $entry ) {
 			$slug = isset( $entry['ability_pack_slug'] ) ? (string) $entry['ability_pack_slug'] : '';
@@ -168,12 +205,45 @@ final class PackUpdater {
 			}
 		}
 
-		$uap = PluginDirectory::universal_abilities_entry();
+		$uap = PluginDirectory::universal_abilities_entry( $force );
 		if ( null !== $uap ) {
 			$by_slug[ PluginDirectory::UNIVERSAL_ABILITIES_SLUG ] = $uap;
 		}
 
 		return $by_slug;
+	}
+
+	/**
+	 * Whether to refetch the manifests from the network on this pass.
+	 *
+	 * True only when BOTH: (1) we're in a context where blocking I/O is
+	 * acceptable — admin, cron, or WP-CLI, never a front-end request — and
+	 * (2) WordPress's own `last_checked` timestamp has advanced since our last
+	 * refresh, i.e. WP just performed a real update check (scheduled or the
+	 * manual "Check Again"). This ties our manifest freshness to WP's own cadence
+	 * — one fetch per WP check, none in between — instead of an independent TTL.
+	 *
+	 * @param object $transient The update_plugins site transient.
+	 */
+	private function should_refresh( $transient ): bool {
+		$ok_context = is_admin()
+			|| ( function_exists( 'wp_doing_cron' ) && wp_doing_cron() )
+			|| ( defined( 'WP_CLI' ) && WP_CLI );
+		if ( ! $ok_context ) {
+			return false;
+		}
+
+		$wp_checked = isset( $transient->last_checked ) ? (int) $transient->last_checked : 0;
+		if ( $wp_checked <= 0 ) {
+			return false;
+		}
+
+		if ( $wp_checked > (int) get_option( self::SYNC_OPTION, 0 ) ) {
+			update_option( self::SYNC_OPTION, $wp_checked, false );
+			return true;
+		}
+
+		return false;
 	}
 
 	/**

--- a/plugin/src/Services/PluginDirectory.php
+++ b/plugin/src/Services/PluginDirectory.php
@@ -63,15 +63,40 @@ final class PluginDirectory {
 	public const UNIVERSAL_ABILITIES_CACHE_KEY = 'agent_connector_for_wp_uap_index_cache';
 
 	/**
+	 * Failure-backoff markers. When a fetch fails and nothing is cached, we set a
+	 * short-lived marker so repeated calls in the same window skip the network
+	 * instead of each eating a timeout ("negative caching"). A forced refresh
+	 * (an explicit WP "Check Again") ignores the marker and retries.
+	 */
+	public const CACHE_FAIL_KEY               = 'agent_connector_for_wp_directory_fail';
+	public const UNIVERSAL_ABILITIES_FAIL_KEY = 'agent_connector_for_wp_uap_index_fail';
+
+	/**
+	 * How long to suppress refetching after a failure, in seconds.
+	 */
+	private const FAIL_BACKOFF = 10 * MINUTE_IN_SECONDS;
+
+	/**
 	 * Transient lifetime: 12 hours.
 	 */
 	public const CACHE_TTL = 12 * HOUR_IN_SECONDS;
 
 	/**
-	 * Network timeout for the manifest fetch, in seconds. Kept short so a slow or
-	 * unreachable host never stalls an admin page render for long.
+	 * Default network timeout for the manifest fetch, in seconds. Kept short so a
+	 * slow or unreachable host never stalls an admin page render for long.
+	 * Override with the `agent_connector_for_wp_manifest_timeout` filter.
 	 */
 	private const HTTP_TIMEOUT = 5;
+
+	/**
+	 * The manifest fetch timeout after the override filter, floored at 1s so it
+	 * can never be set to a blocking/never value.
+	 */
+	private static function http_timeout(): int {
+		$timeout = (int) apply_filters( 'agent_connector_for_wp_manifest_timeout', self::HTTP_TIMEOUT );
+
+		return max( 1, $timeout );
+	}
 
 	/**
 	 * The ability-pack manifest URL, after the override filter.
@@ -124,12 +149,25 @@ final class PluginDirectory {
 					'url'     => $url,
 				);
 			}
+
+			// Nothing cached AND we recently failed to fetch: skip the network so
+			// repeated background fires don't each eat a timeout. A forced check
+			// bypasses this.
+			if ( get_transient( self::CACHE_FAIL_KEY ) ) {
+				return array(
+					'entries' => array(),
+					'stale'   => false,
+					'error'   => __( 'The ability-pack list is currently unavailable.', 'agent-connector-for-wp' ),
+					'url'     => $url,
+				);
+			}
 		}
 
 		$fetched = self::fetch( $url );
 
 		if ( null !== $fetched ) {
 			set_transient( self::CACHE_KEY, array( 'entries' => $fetched['entries'] ), self::CACHE_TTL );
+			delete_transient( self::CACHE_FAIL_KEY );
 
 			return array(
 				'entries' => $fetched['entries'],
@@ -138,6 +176,9 @@ final class PluginDirectory {
 				'url'     => $url,
 			);
 		}
+
+		// Fetch failed — back off so we don't retry the network on every fire.
+		set_transient( self::CACHE_FAIL_KEY, 1, self::FAIL_BACKOFF );
 
 		// Network/parse failed — fall back to any (possibly stale) cached copy.
 		$cached = self::cached();
@@ -164,6 +205,8 @@ final class PluginDirectory {
 	public static function clear_cache(): void {
 		delete_transient( self::CACHE_KEY );
 		delete_transient( self::UNIVERSAL_ABILITIES_CACHE_KEY );
+		delete_transient( self::CACHE_FAIL_KEY );
+		delete_transient( self::UNIVERSAL_ABILITIES_FAIL_KEY );
 	}
 
 	/**
@@ -200,6 +243,12 @@ final class PluginDirectory {
 			if ( is_array( $cached ) ) {
 				return $cached;
 			}
+
+			// Nothing cached AND we recently failed: skip the network. A forced
+			// check bypasses this.
+			if ( get_transient( self::UNIVERSAL_ABILITIES_FAIL_KEY ) ) {
+				return null;
+			}
 		}
 
 		$entry = self::normalize_universal_abilities_entry(
@@ -208,10 +257,12 @@ final class PluginDirectory {
 
 		if ( null !== $entry ) {
 			set_transient( self::UNIVERSAL_ABILITIES_CACHE_KEY, $entry, self::CACHE_TTL );
+			delete_transient( self::UNIVERSAL_ABILITIES_FAIL_KEY );
 			return $entry;
 		}
 
-		// Network/parse failed — fall back to any (possibly stale) cached copy.
+		// Fetch failed — back off, then fall back to any (possibly stale) cached copy.
+		set_transient( self::UNIVERSAL_ABILITIES_FAIL_KEY, 1, self::FAIL_BACKOFF );
 		$cached = get_transient( self::UNIVERSAL_ABILITIES_CACHE_KEY );
 		return is_array( $cached ) ? $cached : null;
 	}
@@ -281,7 +332,7 @@ final class PluginDirectory {
 		$response = wp_remote_get(
 			$url,
 			array(
-				'timeout'    => self::HTTP_TIMEOUT,
+				'timeout'    => self::http_timeout(),
 				'user-agent' => 'AgentConnectorForWp/' . ( defined( 'AGENT_CONNECTOR_FOR_WP_VERSION' ) ? AGENT_CONNECTOR_FOR_WP_VERSION : 'dev' ),
 				'headers'    => array( 'Accept' => 'application/json' ),
 			)


### PR DESCRIPTION
## Why

Our pack/Universal-Abilities updater runs **inside WordPress's own update-check flow** (`pre_set_site_transient_update_plugins`). If that hook hangs, throws, or misbehaves, it's not just our feature that breaks — it can stall the Plugins screen or take down WordPress's whole update check. This makes the hook defensive so the worst case is always "no update offered," never a broken WP.

Follows the earlier Universal Abilities updater work (#65).

## Defenses added

1. **Can't throw into WP.** The entire injection is wrapped in `try/catch (\Throwable)`. On any error we hand WordPress back the transient exactly as received (logged only under `WP_DEBUG`). A bug in our code can never escape into core's update flow.

2. **Refetch in lockstep with WP's own check (`last_checked`).** Instead of an independent TTL that drifts out of sync with WordPress, we refetch our manifests only when WP's `last_checked` timestamp advances — i.e. when WP genuinely ran a check (scheduled cron *or* the manual "Check Again"). Every other fire of the filter serves cache. Result: *"when WordPress checks for updates, it checks for ours too, with fresh data"* — and **exactly one fetch per WP cycle**, not per filter fire.

3. **Context gate.** Blocking network I/O happens only in `admin` / `cron` / `WP-CLI` — never on a front-end request.

4. **Negative caching.** A failed fetch sets a 10-minute backoff marker so repeated background fires don't each eat a timeout; a **forced** check (explicit "Check Again") bypasses the backoff and retries. Cleared on success and by `clear_cache()`.

5. **Filterable timeout.** `agent_connector_for_wp_manifest_timeout` (default 5s, floored at 1s) so an operator on a slow link can tune it without touching code.

## Files
- `PackUpdater` — try/catch wrapper (`inject_updates` → `do_inject`), `should_refresh()` (context gate + `last_checked` lockstep), `entries_by_slug($force)`.
- `PluginDirectory` — filterable `http_timeout()`, failure-backoff transients for both manifests (`get()` and `universal_abilities_entry()`), `clear_cache()` drops them.

## Verification (sandbox)
- **Guard:** a `Throwable` thrown from the fetch path returns the transient intact — no fatal, no exception escapes.
- **Timeout filter:** the overridden value (2s) is applied to the actual request args.
- **Negative cache:** two non-forced calls during an outage → **one** network hit; the backoff marker is set; a forced call bypasses it (second hit).
- **Lockstep:** fire with a new `last_checked` fetches; a repeat fire with the same `last_checked` does **not**; an advanced `last_checked` fetches again.
- **No regression:** the real (unmocked) manifest path still fetches 1.0.1 and injects correctly (listed under `no_update` when installed == latest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)