### PR TITLE
fix: rebase-retry release pushes so concurrent releases don't fail

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -116,8 +116,25 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add plugin/agent-connector-for-wp.php
           git commit -m "chore(release): ${{ steps.ver.outputs.tag }} [skip ci]"
+
+          # Push the bump commit, rebasing onto any concurrent push and retrying.
+          # The sibling release workflow (default-abilities-release.yml) also
+          # pushes a [skip ci] commit to this branch, so two releases triggered by
+          # one merge can race here. Our change touches a different file than
+          # theirs, so a rebase always applies cleanly and both releases land.
+          n=0
+          until git push origin "HEAD:${GITHUB_REF_NAME}"; do
+            n=$((n + 1))
+            if [ "$n" -ge 5 ]; then
+              echo "::error::could not push the release commit after $n attempts"
+              exit 1
+            fi
+            echo "Push rejected — rebasing onto ${GITHUB_REF_NAME} and retrying ($n)…"
+            git pull --rebase --autostash origin "${GITHUB_REF_NAME}"
+          done
+
+          # Tag the commit that actually landed (after any rebase), then push it.
           git tag -a "${{ steps.ver.outputs.tag }}" -m "${{ steps.ver.outputs.tag }}"
-          git push origin "HEAD:${GITHUB_REF_NAME}"
           git push origin "${{ steps.ver.outputs.tag }}"
 
       - name: Set up PHP

--- a/.github/workflows/default-abilities-release.yml
+++ b/.github/workflows/default-abilities-release.yml
@@ -130,8 +130,25 @@ jobs:
           # Nothing to commit on a first release where the header already matches;
           # still tag it so the series has a baseline.
           git commit -m "chore(release): ${{ steps.ver.outputs.tag }} [skip ci]" || echo "No header change to commit."
+
+          # Push the bump commit, rebasing onto any concurrent push and retrying.
+          # The sibling release workflow (auto-release.yml) also pushes a [skip ci]
+          # commit to this branch, so two releases triggered by one merge can race
+          # here. Our change touches a different file than theirs, so a rebase
+          # always applies cleanly and both releases land.
+          n=0
+          until git push origin "HEAD:${GITHUB_REF_NAME}"; do
+            n=$((n + 1))
+            if [ "$n" -ge 5 ]; then
+              echo "::error::could not push the release commit after $n attempts"
+              exit 1
+            fi
+            echo "Push rejected — rebasing onto ${GITHUB_REF_NAME} and retrying ($n)…"
+            git pull --rebase --autostash origin "${GITHUB_REF_NAME}"
+          done
+
+          # Tag the commit that actually landed (after any rebase), then push it.
           git tag -a "${{ steps.ver.outputs.tag }}" -m "${{ steps.ver.outputs.tag }}"
-          git push origin "HEAD:${GITHUB_REF_NAME}"
           git push origin "${{ steps.ver.outputs.tag }}"
 
       - name: Build plugin zip


### PR DESCRIPTION
## The bug

Both release workflows push a `[skip ci]` version-bump commit to `master`:
- `auto-release.yml` bumps `plugin/agent-connector-for-wp.php`
- `default-abilities-release.yml` bumps `universal-abilities-plugin/default-abilities-plugin.php`

A single merge that touches **both** plugin areas (or two manual dispatches, as when I cut v1.22.1 alongside the Universal Abilities release) triggers both workflows. They race on the push to `master` — the second one is rejected `! [rejected] (non-fast-forward)` and its release **fails**. That's exactly what happened cutting v1.22.1: the main-plugin release had to be re-dispatched by hand after the UAP release won the push.

## The fix

Wrap the `git push` of the bump commit in a **rebase-and-retry loop** (up to 5 attempts) in both workflows:

```sh
git commit -m "chore(release): TAG [skip ci]"
n=0
until git push origin "HEAD:${GITHUB_REF_NAME}"; do
  n=$((n + 1)); [ "$n" -ge 5 ] && { echo "::error::…"; exit 1; }
  git pull --rebase --autostash origin "${GITHUB_REF_NAME}"
done
git tag -a "TAG" -m "TAG"      # tag AFTER the push, so it points at the landed commit
git push origin "TAG"
```

The two workflows bump **different files**, so a rebase onto the sibling's commit always applies cleanly and **both releases complete** — no drops, no manual re-dispatch. The tag is now created *after* the push succeeds, so it always points at the commit that actually landed on the branch (post-rebase), never an orphaned SHA.

## Why rebase-retry, not a shared concurrency group

A shared `concurrency.group` across the two workflows would serialize them — but with `cancel-in-progress: false`, a third run queuing behind two others gets **cancelled**, which could silently drop a release in a rapid-merge scenario. Rebase-retry has **no drop risk**: every triggered release runs to completion. Per-workflow concurrency groups stay as-is (they correctly serialize two runs of the *same* workflow).

## Verification

- `bash -n` on the retry loop: valid.
- Simulated an always-failing push: the loop retries and **gives up cleanly after 5 attempts** (confirms no `set -e` surprise from the `n=$((n + 1))` arithmetic).
- No tabs; structure mirrors the existing steps.

Full end-to-end proof will come the next time a merge triggers both workflows at once — they should both go green instead of one failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)