### PR TITLE
fix: revoke the token family when a rotated refresh token is replayed

### DIFF
--- a/plugin/src/OAuth/Db.php
+++ b/plugin/src/OAuth/Db.php
@@ -453,21 +453,26 @@ final class Db {
 	}
 
 	/**
-	 * Get a live (non-revoked, non-expired) token row by refresh token hash.
+	 * Get a token row by refresh token hash in ANY state — revoked included.
+	 *
+	 * The refresh grant needs this to tell "revoked but known" apart from
+	 * "unknown": a revoked row is evidence of rotation reuse (the caller revokes
+	 * the whole client family), while an unknown hash is just an invalid grant.
+	 * Revoked rows are only retained for a day ({@see cleanup_expired_tokens}),
+	 * so that retention window is also the reuse-detection window.
 	 *
 	 * @param string $refresh_hash The hashed refresh token.
 	 * @return array<string,mixed>|null
 	 */
-	public static function get_token_by_refresh_hash( string $refresh_hash ): array|null {
+	public static function find_token_by_refresh_hash( string $refresh_hash ): array|null {
 		global $wpdb;
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Custom OAuth tables, no WP cache API applicable.
 		$row = $wpdb->get_row(
 			$wpdb->prepare(
-				'SELECT * FROM %i WHERE refresh_token_hash = %s AND revoked = 0 AND refresh_expires_at > %s',
+				'SELECT * FROM %i WHERE refresh_token_hash = %s',
 				self::table_tokens(),
-				$refresh_hash,
-				gmdate( 'Y-m-d H:i:s' )
+				$refresh_hash
 			),
 			ARRAY_A
 		);
@@ -497,24 +502,31 @@ final class Db {
 	}
 
 	/**
-	 * Revoke a token pair by refresh token hash.
+	 * Revoke a token pair by refresh token hash — an atomic claim.
+	 *
+	 * Conditional on `revoked = 0`, mirroring {@see mark_code_used()}: rotation
+	 * treats a refresh token as single-use, and the conditional UPDATE means
+	 * exactly one of N concurrent refreshes of the same token can win. A false
+	 * return therefore distinguishes "already revoked" from "revoked just now",
+	 * which the refresh grant uses as its reuse signal.
 	 *
 	 * @param string $refresh_hash The hashed refresh token.
-	 * @return bool True if a token was revoked.
+	 * @return bool True if this caller revoked it; false if it was already
+	 *              revoked (or unknown).
 	 */
 	public static function revoke_token_by_refresh_hash( string $refresh_hash ): bool {
 		global $wpdb;
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Custom OAuth tables, no WP cache API applicable.
-		$updated = $wpdb->update(
-			self::table_tokens(),
-			array( 'revoked' => 1 ),
-			array( 'refresh_token_hash' => $refresh_hash ),
-			array( '%d' ),
-			array( '%s' )
+		$updated = $wpdb->query(
+			$wpdb->prepare(
+				'UPDATE %i SET revoked = 1 WHERE refresh_token_hash = %s AND revoked = 0',
+				self::table_tokens(),
+				$refresh_hash
+			)
 		);
 
-		return $updated > 0;
+		return 1 === (int) $updated;
 	}
 
 	/**

--- a/plugin/src/OAuth/Token.php
+++ b/plugin/src/OAuth/Token.php
@@ -162,9 +162,25 @@ final class Token {
 		}
 
 		$refresh_hash = Db::hash_token( $refresh_token );
-		$token_row    = Db::get_token_by_refresh_hash( $refresh_hash );
+		$token_row    = Db::find_token_by_refresh_hash( $refresh_hash );
 
 		if ( null === $token_row ) {
+			return self::oauth_error( 'invalid_grant', 'The provided refresh token is invalid, expired, or revoked.' );
+		}
+
+		// Rotation reuse: presenting an already-rotated refresh token means it
+		// leaked (OAuth 2.1 / RFC 9700 §4.14.2) — the thief and the legitimate
+		// client each hold a copy, and whichever refreshed second is now
+		// showing us the stolen one. Revoke every token for the client so the
+		// pair minted from the FIRST redemption dies too, exactly as a replayed
+		// authorization code is handled. Detection is bounded by how long
+		// revoked rows are retained (a day — see Db::cleanup_expired_tokens).
+		if ( 1 === (int) $token_row['revoked'] ) {
+			Db::revoke_all_for_client( (string) $token_row['client_id'] );
+			return self::oauth_error( 'invalid_grant', 'The provided refresh token is invalid, expired, or revoked.' );
+		}
+
+		if ( strtotime( (string) $token_row['refresh_expires_at'] ) < time() ) {
 			return self::oauth_error( 'invalid_grant', 'The provided refresh token is invalid, expired, or revoked.' );
 		}
 
@@ -177,8 +193,14 @@ final class Token {
 			return $client_auth_error;
 		}
 
-		// Rotate: revoke the old pair, then issue a new one.
-		Db::revoke_token_by_refresh_hash( $refresh_hash );
+		// Rotate: claim the old pair, then issue a new one. The claim is a
+		// conditional UPDATE (single-use, like authorization codes), so losing
+		// it means a concurrent request rotated this token first — a reuse,
+		// handled the same as the revoked-row check above.
+		if ( ! Db::revoke_token_by_refresh_hash( $refresh_hash ) ) {
+			Db::revoke_all_for_client( (string) $token_row['client_id'] );
+			return self::oauth_error( 'invalid_grant', 'The provided refresh token is invalid, expired, or revoked.' );
+		}
 
 		$new_tokens = Db::insert_token(
 			array(


### PR DESCRIPTION
## What

The refresh grant now distinguishes "revoked but known" from "unknown": redeeming an already-rotated refresh token revokes **every** token for that client (`Db::revoke_all_for_client`), instead of just returning `invalid_grant`. The rotation revoke itself became an atomic conditional `UPDATE … WHERE revoked = 0` (mirroring `mark_code_used`), so two concurrent redemptions of one refresh token can't both mint pairs — the loser is treated as reuse. Unused `get_token_by_refresh_hash` removed in favor of the any-state lookup.

## Why

Rotation reuse means theft (OAuth 2.1 / RFC 9700 §4.14.2): the thief and the legitimate client each hold a copy, and whoever refreshed second is showing us the stolen one. Previously the attacker who redeemed first *kept a valid pair* while the real client just errored and re-authed. Authorization-code replay already got this exact treatment; this applies it one layer up. Detection is bounded by the 1-day retention of revoked rows (`cleanup_expired_tokens`), which covers the realistic race window.

## Verified

Live against the sandbox token endpoint: rotate a real pair (200, new tokens issued) → replay the old refresh token (`invalid_grant`) → the **new** pair from the first rotation is now also dead (`invalid_grant`). Error responses stay generic per RFC 6749.

🤖 Generated with [Claude Code](https://claude.com/claude-code)