### PR TITLE
feat: rate-limit the public OAuth endpoints

### DIFF
--- a/plugin/src/OAuth/Db.php
+++ b/plugin/src/OAuth/Db.php
@@ -721,6 +721,35 @@ final class Db {
 	}
 
 	/**
+	 * Delete token-less client registrations older than $ttl seconds.
+	 *
+	 * The legitimate flow goes register → consent → token within minutes, so a
+	 * registration still without a token a day later is abandoned or spam and
+	 * only occupies a pending-pool slot ({@see Server::handle_register}). Also
+	 * catches clients whose token rows have all been cleaned up (grant expired
+	 * 30+ days ago): compliant DCR clients simply re-register.
+	 *
+	 * @param int $ttl Minimum age in seconds before a token-less registration
+	 *                 is removed.
+	 * @return int Number of registrations removed.
+	 */
+	public static function delete_stale_clients_without_tokens( int $ttl = DAY_IN_SECONDS ): int {
+		global $wpdb;
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Custom OAuth tables, no WP cache API applicable.
+		$deleted = $wpdb->query(
+			$wpdb->prepare(
+				'DELETE c FROM %i c LEFT JOIN %i t ON t.client_id = c.client_id WHERE t.id IS NULL AND c.created_at < %s',
+				self::table_clients(),
+				self::table_tokens(),
+				gmdate( 'Y-m-d H:i:s', time() - $ttl )
+			)
+		);
+
+		return (int) $deleted;
+	}
+
+	/**
 	 * Delete token rows that can no longer authenticate anything.
 	 *
 	 * Refresh rotation revokes a row and writes a replacement on every refresh,

--- a/plugin/src/OAuth/RateLimiter.php
+++ b/plugin/src/OAuth/RateLimiter.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Per-IP rate limiting for the public OAuth endpoints.
+ *
+ * @package AgentConnectorForWp
+ */
+
+declare( strict_types=1 );
+
+namespace AgentConnectorForWp\OAuth;
+
+use AgentConnectorForWp\Support\Helpers;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Fixed-window per-IP throttle backed by transients.
+ *
+ * The OAuth protocol endpoints (/register, /token, /revoke) are public by
+ * spec, so nothing authenticates a caller before they cost us DB work. Token
+ * entropy already makes brute force pointless (256-bit values); what this
+ * limits is resource abuse — an anonymous flood filling the clients table via
+ * DCR or tying PHP up in token-endpoint crypto and queries.
+ *
+ * Deliberately best-effort: the read-increment-write is not atomic, so a burst
+ * racing on one uncached-transient window can overshoot the limit by a few
+ * requests. That is fine for abuse control and avoids paying for a lock on
+ * every legitimate request.
+ */
+final class RateLimiter {
+
+	/**
+	 * Transient key prefix. Full key: prefix + bucket + '_' + sha256(ip).
+	 */
+	private const KEY_PREFIX = 'acfw_oauth_rl_';
+
+	/**
+	 * Whether a request from the current caller is within the bucket's limit,
+	 * counting this request against the window when it is.
+	 *
+	 * An empty client IP (a proxy stripping REMOTE_ADDR) is never throttled:
+	 * the request cannot be attributed to a source, and failing closed would
+	 * take the whole OAuth flow down for everyone behind that proxy.
+	 *
+	 * @param string $bucket Endpoint bucket ('register', 'token', 'revoke').
+	 * @param int    $limit  Maximum requests per window.
+	 * @param int    $window Window length in seconds.
+	 */
+	public static function allow( string $bucket, int $limit, int $window ): bool {
+		$ip = Helpers::client_ip();
+		if ( '' === $ip ) {
+			return true;
+		}
+
+		/**
+		 * Filters the per-IP request limit for one OAuth endpoint bucket.
+		 *
+		 * @param int    $limit  Maximum requests per window (0 disables the limit).
+		 * @param string $bucket The endpoint bucket: 'register', 'token', or 'revoke'.
+		 */
+		$limit = (int) apply_filters( 'agent_connector_for_wp_oauth_rate_limit', $limit, $bucket );
+		if ( $limit <= 0 ) {
+			return true;
+		}
+
+		// The IP is hashed so the key stays fixed-length (IPv6 + prefix would
+		// near the transient name limit) and raw IPs stay out of wp_options.
+		$key   = self::KEY_PREFIX . $bucket . '_' . hash( 'sha256', $ip );
+		$count = (int) get_transient( $key );
+
+		if ( $count >= $limit ) {
+			return false;
+		}
+
+		set_transient( $key, $count + 1, $window );
+
+		return true;
+	}
+}

--- a/plugin/src/OAuth/Server.php
+++ b/plugin/src/OAuth/Server.php
@@ -208,6 +208,37 @@ final class Server {
 	 * @return WP_REST_Response|WP_Error
 	 */
 	public static function handle_register( WP_REST_Request $request ): WP_REST_Response|WP_Error {
+		// Registration is unauthenticated by design (RFC 7591), so it is the
+		// cheapest endpoint to flood. Throttle per IP, prune registrations that
+		// never became a connection, and refuse outright once the pending pool
+		// is full — a flood can no longer grow the clients table without bound.
+		if ( ! RateLimiter::allow( 'register', 10, HOUR_IN_SECONDS ) ) {
+			return new WP_Error(
+				'rate_limited',
+				'Too many client registrations from this address. Try again later.',
+				array( 'status' => 429 )
+			);
+		}
+
+		Db::delete_stale_clients_without_tokens();
+
+		/**
+		 * Filters the maximum number of pending (token-less) client
+		 * registrations kept at once. Registrations only count against this
+		 * cap until an administrator approves them on the consent screen, so
+		 * real connections are never blocked by it.
+		 *
+		 * @param int $max_pending Maximum pending registrations (default 100).
+		 */
+		$max_pending = (int) apply_filters( 'agent_connector_for_wp_oauth_max_pending_clients', 100 );
+		if ( Db::count_clients_without_tokens() >= $max_pending ) {
+			return new WP_Error(
+				'temporarily_unavailable',
+				'Too many pending client registrations. Try again later.',
+				array( 'status' => 503 )
+			);
+		}
+
 		$body = $request->get_json_params();
 		$body = is_array( $body ) ? $body : array();
 

--- a/plugin/src/OAuth/Token.php
+++ b/plugin/src/OAuth/Token.php
@@ -44,6 +44,13 @@ final class Token {
 	 * @return WP_REST_Response|WP_Error
 	 */
 	public static function handle( WP_REST_Request $request ): WP_REST_Response|WP_Error {
+		// Public endpoint (RFC 6749): throttle per IP so an anonymous flood
+		// can't tie PHP up in grant validation. Generous for real clients — a
+		// connection refreshes roughly hourly.
+		if ( ! RateLimiter::allow( 'token', 30, MINUTE_IN_SECONDS ) ) {
+			return self::oauth_error( 'temporarily_unavailable', 'Too many token requests from this address. Try again shortly.', 429 );
+		}
+
 		$grant_type = sanitize_text_field( (string) ( $request->get_param( 'grant_type' ) ?? '' ) );
 
 		// Opportunistic cleanup. Rotation leaves a dead token row behind on
@@ -214,6 +221,19 @@ final class Token {
 	 * @param WP_REST_Request $request The incoming REST request.
 	 */
 	public static function handle_revoke( WP_REST_Request $request ): WP_REST_Response {
+		// RFC 7009 §2.2.1 names 503 as the too-many-requests response and has
+		// the client treat the token as still existing, so a throttled caller
+		// retries instead of assuming success.
+		if ( ! RateLimiter::allow( 'revoke', 30, MINUTE_IN_SECONDS ) ) {
+			return new WP_REST_Response(
+				array(
+					'error'             => 'temporarily_unavailable',
+					'error_description' => 'Too many revocation requests from this address. Try again shortly.',
+				),
+				503
+			);
+		}
+
 		$token      = sanitize_text_field( (string) ( $request->get_param( 'token' ) ?? '' ) );
 		$token_hint = sanitize_text_field( (string) ( $request->get_param( 'token_type_hint' ) ?? '' ) );
 


### PR DESCRIPTION
## What

New `OAuth\RateLimiter` — a best-effort per-IP fixed-window throttle backed by transients (IPs stored hashed), applied to the three endpoints that are public by spec:

- `/register`: 10/hour per IP (429), plus a pending-pool cap — token-less registrations older than a day are pruned on each attempt, and registration refuses with 503 once 100 are pending (`agent_connector_for_wp_oauth_max_pending_clients` filter).
- `/token`: 30/min per IP (429).
- `/revoke`: 30/min per IP, returning **503** per RFC 7009 §2.2.1 so a throttled client treats the token as still existing and retries.

Per-bucket limits are tunable via the `agent_connector_for_wp_oauth_rate_limit` filter (0 disables). Callers with no attributable IP are not throttled, so a proxy stripping `REMOTE_ADDR` can't take the flow down for everyone behind it.

## Why

These endpoints are unauthenticated by design (RFC 7591 / RFC 6749), so before this nothing bounded an anonymous flood: unlimited rows in the clients table via DCR, and free CPU/DB burn on the token endpoint. Token entropy already rules out brute force — this is purely resource-abuse control. The pending cap only counts registrations that never completed consent, so real connections are never blocked by it. Limits are deliberately generous: a real connection registers once and refreshes about hourly.

## Verified

Live against the sandbox: `/register` returns 201 ten times then 429; `/token` returns 400 (bogus grant) thirty times then 429; test rows and throttle transients cleaned up afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)