### PR TITLE
fix: reword the OAuth consent screen warning

### DIFF
--- a/plugin/src/OAuth/Authorize.php
+++ b/plugin/src/OAuth/Authorize.php
@@ -354,7 +354,7 @@ final class Authorize {
 		</div>
 
 		<div class="acfw-oauth-warning">
-			<?php esc_html_e( 'Warning: abilities exposed through Agent Connector can include shell access, PHP evaluation, and filesystem operations. Only authorize applications you trust.', 'agent-connector-for-wp' ); ?>
+			<?php esc_html_e( 'Warning: Agent Connector gives your agent admin-equivalent capabilities to this WordPress installation. Only authorize applications you trust.', 'agent-connector-for-wp' ); ?>
 		</div>
 
 		<div class="acfw-oauth-scopes">


### PR DESCRIPTION
Replaces the consent-page warning copy with a simpler framing of the same risk:

> Warning: Agent Connector gives your agent admin-equivalent capabilities to this WordPress installation. Only authorize applications you trust.

was:

> Warning: abilities exposed through Agent Connector can include shell access, PHP evaluation, and filesystem operations. Only authorize applications you trust.

Text-only change on the OAuth authorize page (`src/OAuth/Authorize.php`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)