### PR TITLE
feat: show the redirect destination on the OAuth consent screen

### DIFF
--- a/plugin/assets/css/oauth-authorize.css
+++ b/plugin/assets/css/oauth-authorize.css
@@ -99,6 +99,14 @@ body {
 	font-weight: 700;
 }
 
+.acfw-oauth-redirect {
+	color: #646970;
+	font-size: 13px;
+	text-align: center;
+	margin-bottom: 12px;
+	overflow-wrap: anywhere;
+}
+
 .acfw-oauth-user {
 	color: #646970;
 	font-size: 13px;

--- a/plugin/src/OAuth/Authorize.php
+++ b/plugin/src/OAuth/Authorize.php
@@ -258,6 +258,30 @@ final class Authorize {
 	}
 
 	/**
+	 * The origin (scheme + host + explicit port) of the client's redirect URI,
+	 * for display on the consent page.
+	 *
+	 * The client name is attacker-chosen (registration is public), so the
+	 * redirect origin is the one signal on the page the client cannot dress
+	 * up: it is where the browser will actually be sent with the
+	 * authorization code. Reduced to the origin because the full URI is
+	 * noise for that judgement (and can be very long).
+	 *
+	 * @param string $redirect_uri The validated redirect URI.
+	 */
+	private static function redirect_destination_label( string $redirect_uri ): string {
+		$scheme = strtolower( (string) wp_parse_url( $redirect_uri, PHP_URL_SCHEME ) );
+		$host   = strtolower( (string) wp_parse_url( $redirect_uri, PHP_URL_HOST ) );
+		$port   = wp_parse_url( $redirect_uri, PHP_URL_PORT );
+
+		if ( '' === $host ) {
+			return $redirect_uri;
+		}
+
+		return $scheme . '://' . $host . ( null !== $port ? ':' . (string) $port : '' );
+	}
+
+	/**
 	 * Extract and sanitize authorization parameters from the request.
 	 *
 	 * @param WP_REST_Request $request The incoming REST request.
@@ -365,6 +389,16 @@ final class Authorize {
 				<?php endforeach; ?>
 			</ul>
 		</div>
+
+		<p class="acfw-oauth-redirect">
+			<?php
+			printf(
+				/* translators: %s: origin (scheme + host) of the client's redirect URI */
+				esc_html__( 'After you authorize, your browser will be sent back to %s to hand the application its access.', 'agent-connector-for-wp' ),
+				'<strong>' . esc_html( self::redirect_destination_label( $params['redirect_uri'] ) ) . '</strong>'
+			);
+			?>
+		</p>
 
 		<p class="acfw-oauth-user">
 			<?php


### PR DESCRIPTION
## What

The OAuth consent page now shows where the browser will be sent after approval, right above the "Logged in as" line:

> After you authorize, your browser will be sent back to **https://claude.ai** to hand the application its access.

Reduced to the redirect URI's origin (`scheme://host[:port]`) — the full URI is long and adds nothing to the trust judgement. Matching muted styling in `oauth-authorize.css` with `overflow-wrap` for long hosts.

## Why

The client name on that page is attacker-chosen (registration is public per RFC 7591), so "Claude is requesting access" can say anything. The redirect origin is the one signal on the page the client cannot dress up: it's where the authorization code actually goes. Gives the admin a second, unforgeable data point before clicking Authorize. (Novamira's consent screen shows the same thing.)

## Verified

Drove the real flow in a browser on the sandbox: registered a client, hit `/authorize`, logged in, and screenshotted the rendered consent page with the new line displayed correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)