### PR TITLE
Update wordpress/mcp-adapter to ^0.6

### DIFF
--- a/plugin/composer.json
+++ b/plugin/composer.json
@@ -8,7 +8,7 @@
 	"require": {
 		"php": ">=8.1",
 		"automattic/jetpack-autoloader": "^5.0",
-		"wordpress/mcp-adapter": "^0.5",
+		"wordpress/mcp-adapter": "^0.6",
 		"yahnis-elsts/plugin-update-checker": "^5.7"
 	},
 	"autoload": {

--- a/plugin/composer.lock
+++ b/plugin/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9b814200deeda4b1fd05c72c403eccf9",
+    "content-hash": "06501a82d0146e8acbb2413037ebee24",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -72,52 +72,47 @@
         },
         {
             "name": "wordpress/mcp-adapter",
-            "version": "v0.5.0",
+            "version": "v0.6.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/WordPress/mcp-adapter.git",
-                "reference": "7bfc49f46b3ea7544dded49d5a606089f825a80b"
+                "url": "https://github.com/WordPress/mcp-adapter",
+                "reference": "23cb53e0b82f39238eec1c38cb055e28aa30fa7c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/mcp-adapter/zipball/7bfc49f46b3ea7544dded49d5a606089f825a80b",
-                "reference": "7bfc49f46b3ea7544dded49d5a606089f825a80b",
+                "url": "https://api.github.com/repos/WordPress/mcp-adapter/zipball/23cb53e0b82f39238eec1c38cb055e28aa30fa7c",
+                "reference": "23cb53e0b82f39238eec1c38cb055e28aa30fa7c",
                 "shasum": ""
             },
             "require": {
+                "automattic/jetpack-autoloader": "^5.0",
                 "ext-json": "*",
                 "php": "^7.4 || ^8.0",
                 "wordpress/php-mcp-schema": "^0.1.0"
             },
             "require-dev": {
-                "automattic/vipwpcs": "^3.0",
+                "automattic/vipwpcs": "^3.1",
                 "php-stubs/wordpress-stubs": "^6.9",
                 "php-stubs/wp-cli-stubs": "^2.12",
-                "phpcompatibility/php-compatibility": "10.x-dev as 9.99.99",
-                "phpcompatibility/phpcompatibility-wp": "^2.1",
+                "phpcompatibility/phpcompatibility-wp": "^3.0.0-alpha",
                 "phpstan/extension-installer": "^1.3",
-                "phpstan/php-8-stubs": "^0.4.24",
-                "phpstan/phpstan": "^2.1.22",
-                "phpstan/phpstan-deprecation-rules": "^2.0.3",
+                "phpstan/php-8-stubs": "^0.4.36",
+                "phpstan/phpstan": "^2.2.6",
+                "phpstan/phpstan-deprecation-rules": "^2.0.5",
                 "phpunit/phpunit": "^9.6",
                 "slevomat/coding-standard": "^8.0",
                 "szepeviktor/phpstan-wordpress": "^2.0",
-                "wp-phpunit/wp-phpunit": "^6.5",
-                "wpackagist-plugin/plugin-check": "^1.6",
+                "wp-phpunit/wp-phpunit": "^7.0",
                 "yoast/phpunit-polyfills": "^4.0"
             },
             "type": "wordpress-plugin",
-            "extra": {
-                "installer-paths": {
-                    "vendor/{$vendor}/{$name}/": [
-                        "wpackagist-plugin/plugin-check"
-                    ]
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "WP\\MCP\\": "includes/"
-                }
+                },
+                "exclude-from-classmap": [
+                    "tests/phpunit/"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -145,20 +140,20 @@
                 "issues": "https://github.com/wordpress/mcp-adapter/issues",
                 "source": "https://github.com/wordpress/mcp-adapter"
             },
-            "time": "2026-04-14T12:12:58+00:00"
+            "time": "2026-08-13T05:16:13+00:00"
         },
         {
             "name": "wordpress/php-mcp-schema",
-            "version": "v0.1.1",
+            "version": "v0.1.3",
             "source": {
                 "type": "git",
-                "url": "https://github.com/WordPress/php-mcp-schema.git",
-                "reference": "e2118ec421ead51a3e17a3d8160f4537727e91b9"
+                "url": "https://github.com/WordPress/php-mcp-schema",
+                "reference": "b2fcf97aa023ce46e9f03493c194a72d5a46bea2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/php-mcp-schema/zipball/e2118ec421ead51a3e17a3d8160f4537727e91b9",
-                "reference": "e2118ec421ead51a3e17a3d8160f4537727e91b9",
+                "url": "https://api.github.com/repos/WordPress/php-mcp-schema/zipball/b2fcf97aa023ce46e9f03493c194a72d5a46bea2",
+                "reference": "b2fcf97aa023ce46e9f03493c194a72d5a46bea2",
                 "shasum": ""
             },
             "require": {
@@ -192,11 +187,7 @@
                 "php",
                 "schema"
             ],
-            "support": {
-                "issues": "https://github.com/WordPress/php-mcp-schema/issues",
-                "source": "https://github.com/WordPress/php-mcp-schema/tree/v0.1.1"
-            },
-            "time": "2026-04-10T19:35:16+00:00"
+            "time": "2026-08-10T09:12:14+00:00"
         },
         {
             "name": "yahnis-elsts/plugin-update-checker",
@@ -259,5 +250,5 @@
         "php": ">=8.1"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/plugin/docs/registering-abilities.md
+++ b/plugin/docs/registering-abilities.md
@@ -291,7 +291,8 @@ lock, and audit log.
 
 You don't need this to use the API, but for transparency: Agent Connector hooks
 the core `wp_register_ability_args` filter and, for **every** ability that will
-be MCP-exposed (`meta.mcp.public === true`) — whether registered through this API
+be MCP-exposed (an explicit `meta.mcp.public` wins; when absent, exposure is
+inherited from `meta.public`) — whether registered through this API
 or via raw `wp_register_ability()` — it overrides `permission_callback` with its
 admin/super-admin check and wraps `execute_callback` with its domain-lock +
 audit chokepoint. This is a security backstop: no ability reachable through the

--- a/plugin/src/Admin/DirectoryPage.php
+++ b/plugin/src/Admin/DirectoryPage.php
@@ -12,6 +12,7 @@ namespace AgentConnectorForWp\Admin;
 
 use AgentConnectorForWp\Services\PluginDirectory;
 use AgentConnectorForWp\Support\Config;
+use AgentConnectorForWp\Support\Governance;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -595,7 +596,7 @@ final class DirectoryPage {
 		$desc        = (string) $ability->get_description();
 		$category    = method_exists( $ability, 'get_category' ) ? (string) $ability->get_category() : '';
 		$meta        = (array) $ability->get_meta();
-		$mcp_public  = isset( $meta['mcp']['public'] ) && true === $meta['mcp']['public'];
+		$mcp_public  = Governance::is_mcp_exposed_meta( $meta );
 		$annotations = isset( $meta['annotations'] ) && is_array( $meta['annotations'] ) ? $meta['annotations'] : array();
 		$input       = $ability->get_input_schema();
 		$output      = method_exists( $ability, 'get_output_schema' ) ? $ability->get_output_schema() : null;

--- a/plugin/src/Rest/SettingsController.php
+++ b/plugin/src/Rest/SettingsController.php
@@ -14,6 +14,7 @@ use AgentConnectorForWp\OAuth\Db as OAuthDb;
 use AgentConnectorForWp\Services\PluginDirectory;
 use AgentConnectorForWp\Support\Config;
 use AgentConnectorForWp\Support\Connection;
+use AgentConnectorForWp\Support\Governance;
 use WP_Application_Passwords;
 use WP_Error;
 use WP_REST_Controller;
@@ -470,7 +471,7 @@ final class SettingsController extends WP_REST_Controller {
 			}
 
 			$meta        = (array) $ability->get_meta();
-			$mcp_public  = isset( $meta['mcp']['public'] ) && true === $meta['mcp']['public'];
+			$mcp_public  = Governance::is_mcp_exposed_meta( $meta );
 			$annotations = isset( $meta['annotations'] ) && is_array( $meta['annotations'] ) ? $meta['annotations'] : array();
 			$output      = method_exists( $ability, 'get_output_schema' ) ? $ability->get_output_schema() : null;
 

--- a/plugin/src/Support/Governance.php
+++ b/plugin/src/Support/Governance.php
@@ -12,6 +12,7 @@ namespace AgentConnectorForWp\Support;
 
 use AgentConnectorForWp\Services\AuditLogger;
 use AgentConnectorForWp\Services\WrappedHandler;
+use WP\MCP\Abilities\McpAbilityExposure;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -20,9 +21,11 @@ defined( 'ABSPATH' ) || exit;
  * uses anyone else's (or no) authentication.
  *
  * The default WordPress MCP server (wordpress/mcp-adapter) auto-exposes ANY
- * ability whose meta carries `mcp.public === true`, regardless of which plugin
- * registered it. That is convenient — but it means a third party could register
- * a public ability with `permission_callback => __return_true` and bypass our
+ * ability that resolves as MCP-public (an explicit `mcp.public` wins; when it is
+ * absent, exposure is inherited from the high-level `meta.public` flag — see
+ * the adapter's McpAbilityExposure), regardless of which plugin registered it.
+ * That is convenient — but it means a third party could register a public
+ * ability with `permission_callback => __return_true` and bypass our
  * admin/super-admin gate. To prevent that, this layer hooks the core
  * `wp_register_ability_args` filter (which fires for EVERY `wp_register_ability()`
  * call) and, for every ability that will be MCP-exposed, rewrites its arguments
@@ -93,23 +96,24 @@ final class Governance {
 	 * Whether this ability will be exposed over our MCP server and therefore
 	 * must be governed.
 	 *
-	 * An ability is MCP-exposed when its meta carries `mcp.public === true` — the
-	 * exact flag the adapter's DefaultServerFactory keys on. Integrators can
-	 * exempt specific ability names through the `agent_connector_for_wp_govern_ability`
-	 * filter (default: govern everything public).
+	 * Exposure is resolved exactly like the adapter's DefaultServerFactory does
+	 * (see {@see self::is_mcp_exposed_meta()}). Integrators can exempt specific
+	 * ability names through the `agent_connector_for_wp_govern_ability` filter
+	 * (default: govern everything exposed).
 	 *
 	 * @param array<string,mixed> $args The ability registration arguments.
 	 * @param string              $name The ability name.
 	 */
 	private static function should_govern( array $args, string $name ): bool {
-		$is_public = isset( $args['meta']['mcp']['public'] ) && true === $args['meta']['mcp']['public'];
+		$meta      = isset( $args['meta'] ) && is_array( $args['meta'] ) ? $args['meta'] : array();
+		$is_public = self::is_mcp_exposed_meta( $meta );
 
 		/**
 		 * Filters whether a given MCP-exposed ability is governed by Agent
 		 * Connector's auth / domain-lock / audit chokepoint.
 		 *
 		 * Defaults to true for every ability that is exposed over our MCP server
-		 * (mcp.public === true) and false for everything else. Return false for a
+		 * (resolves as MCP-public) and false for everything else. Return false for a
 		 * specific name only if an integrator deliberately wants to take over
 		 * authentication for that ability — doing so means our admin gate, domain
 		 * lock, and audit log no longer apply to it.
@@ -121,6 +125,34 @@ final class Governance {
 		 * @param array<string,mixed> $args   The ability registration arguments.
 		 */
 		return (bool) apply_filters( 'agent_connector_for_wp_govern_ability', $is_public, $name, $args );
+	}
+
+	/**
+	 * Whether ability meta resolves to MCP exposure, matching the adapter's own
+	 * resolution (mcp-adapter ≥ 0.6): an explicit `mcp.public` wins; when it is
+	 * absent, exposure is inherited from the high-level `meta.public` flag; a
+	 * malformed `meta.mcp` fails closed.
+	 *
+	 * Defers to the bundled adapter's McpAbilityExposure so the two can never
+	 * drift. The mirror below only runs when an older adapter (< 0.6, class
+	 * absent) was loaded by another plugin — there, applying the 0.6 semantics
+	 * can only over-govern, which is the safe direction.
+	 *
+	 * @param array<string,mixed> $meta The ability meta.
+	 */
+	public static function is_mcp_exposed_meta( array $meta ): bool {
+		if ( class_exists( McpAbilityExposure::class ) ) {
+			return McpAbilityExposure::is_meta_public( $meta );
+		}
+
+		$mcp_meta = $meta['mcp'] ?? array();
+		if ( ! is_array( $mcp_meta ) ) {
+			return false;
+		}
+		if ( isset( $mcp_meta['public'] ) ) {
+			return (bool) $mcp_meta['public'];
+		}
+		return true === ( $meta['public'] ?? false );
 	}
 
 	/**


### PR DESCRIPTION
Updates the bundled `wordpress/mcp-adapter` from v0.5.0 to v0.6.1 (the latest release). Its dependency `wordpress/php-mcp-schema` moves from v0.1.1 to v0.1.3.

## Why there are code changes too

In 0.5, an ability was only exposed over MCP if it was registered with `meta.mcp.public = true`. **In 0.6, an ability is also exposed if it just has `meta.public = true`** (the `mcp.public` flag still wins when set).

Three places in this plugin assumed the old rule, so without changes they'd disagree with what the adapter actually exposes:

1. **The security backstop** (`Support\Governance`). It forces our admin auth, domain lock, and audit log onto every MCP-exposed ability. Under the old check, an ability with only `meta.public = true` would now be reachable over MCP **without any of those protections**. This is the important fix.
2. **The abilities browser** (`Admin\DirectoryPage`) — its "MCP" column would show "no" for abilities that are actually exposed.
3. **The REST API** (`Rest\SettingsController`) — same issue with its `mcp_public` field.

All three now use one shared check, `Governance::is_mcp_exposed_meta()`, which asks the adapter's own resolver (`McpAbilityExposure`) so our answer always matches the adapter's. The docs in `plugin/docs/registering-abilities.md` were updated to describe the new rule.

## Anything else to worry about?

No. I checked every other place the plugin touches the adapter (boot call, hooks, filter names, REST route, observability interface) — all unchanged in 0.6.1. The rest of the 0.6 release is bug fixes we simply inherit (multisite session scoping, protocol fixes, WP-CLI output fixes).

Heads-up for later, unrelated to this PR: mcp-adapter's *next* release (unreleased trunk) deprecates bundling the adapter as a library entirely, in favor of a canonical wp.org plugin. Bundling keeps working for now but will start logging deprecation notices. Worth planning a migration separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FLbqXrEtSMbeHrxqZ2fx4y